### PR TITLE
Document single-port operation and the provider title knob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Added
+
+- Native macOS menu bar app in `macos/MenuBarApp` (Swift/AppKit, SwiftPM): short status
+  icon, live health check, start/stop of the proxy as a child process, open logs,
+  reveal log file, copy port. Build with `swift build` in `macos/MenuBarApp` (macOS 13+).
+
 ### Fixed
 
 - Reference catalog `contrib/opencode-go-catalog.json` now ships with the `ModelsCache` wrapper
@@ -9,6 +15,9 @@
   top-level fields — the previous bare `{"models": [...]}` caused the model picker to fall back
   to "Custom" instead of showing the full list. The CLI tolerated the bare format, so this only
   surfaced in the desktop app.
+- SIGTERM graceful shutdown: `serve_forever` now runs on a background thread so the signal
+  handler's `server.shutdown()` no longer deadlocks on the main thread, leaving the process
+  unkillable via SIGTERM (launchd/systemd stop, menu bar Stop).
 
 ## [0.1.2] - 2026-06-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@
   icon, live health check, start/stop of the proxy as a child process, open logs,
   reveal log file, copy port. Build with `swift build` in `macos/MenuBarApp` (macOS 13+).
 
+### Changed
+
+- README: document that the proxy exposes a single HTTP port (`OPENCODE_GO_PROXY_PORT`,
+  default 8787) with no admin/control channel, how to verify what is listening
+  (`lsof -nP -iTCP:8787 -sTCP:LISTEN`), and how to shorten the Codex provider label
+  (edit `[model_providers.opencode-go] name` in `~/.codex/config.toml`).
+### Changed
+
+- README: document that the proxy exposes a single HTTP port (`OPENCODE_GO_PROXY_PORT`,
+  default 8787) with no admin/control channel, how to verify what is listening
+  (`lsof -nP -iTCP:8787 -sTCP:LISTEN`), and how to shorten the Codex provider label
+  (edit `[model_providers.opencode-go] name` in `~/.codex/config.toml`).
+
 ### Fixed
 
 - Reference catalog `contrib/opencode-go-catalog.json` now ships with the `ModelsCache` wrapper

--- a/README.md
+++ b/README.md
@@ -222,6 +222,24 @@ All flags have environment variable defaults:
 
 The proxy accepts both `/responses` and `/v1/responses`.
 
+**One HTTP port only.** The proxy binds a single listener: `OPENCODE_GO_PROXY_PORT`
+(default `8787`). There is no admin port, control channel, or secondary service. If
+something else already listens on the port, the proxy fails to bind — check with
+`lsof -nP -iTCP:8787 -sTCP:LISTEN` before starting a second instance (for example, do
+not run the menu bar app's proxy and the launchd agent at the same time).
+
+**Short provider name.** The long "opencode go/" label in the Codex model picker comes
+from the provider config in `~/.codex/config.toml`, not from this proxy. Shorten it by
+editing the provider `name`:
+
+```toml
+[model_providers.opencode-go]
+name = "Go"  # shows as "Go" instead of "opencode go/"
+```
+
+The reference catalog's per-model `display_name` values are already short
+("DeepSeek V4 Flash", "Kimi K2.7 Code", etc).
+
 ## Model catalog
 
 Without a catalog entry, Codex prints a model metadata warning every turn. A reference catalog
@@ -267,6 +285,11 @@ Set `model_catalog_json` in Codex config and copy the reference catalog:
 
 **Connection refused on localhost:8787**
 Proxy isn't running. Start it: `opencode-go-proxy` or check `launchctl list | grep opencode`.
+
+**Port already in use**
+Only one proxy instance can bind 8787. Confirm what is listening:
+`lsof -nP -iTCP:8787 -sTCP:LISTEN`. If a stale instance holds the port, stop it before
+starting another.
 
 **API key not found**
 Set `OPENCODE_GO_API_KEY` env var or add to macOS keychain:

--- a/macos/MenuBarApp/.gitignore
+++ b/macos/MenuBarApp/.gitignore
@@ -1,0 +1,2 @@
+.build/
+.swiftpm/

--- a/macos/MenuBarApp/Package.swift
+++ b/macos/MenuBarApp/Package.swift
@@ -1,0 +1,15 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "OpenCodeGoMenuBar",
+    platforms: [
+        .macOS(.v13)
+    ],
+    targets: [
+        .executableTarget(
+            name: "OpenCodeGoMenuBar",
+            path: "Sources/OpenCodeGoMenuBar"
+        )
+    ]
+)

--- a/macos/MenuBarApp/README.md
+++ b/macos/MenuBarApp/README.md
@@ -1,0 +1,38 @@
+# OpenCode Go Menu Bar App
+
+A native macOS menu bar app (Swift + AppKit, Swift Package Manager) that controls the
+opencode-go-proxy Python bridge.
+
+The menu bar shows a small branch icon (no long "opencode go/" text). The menu shows:
+
+- status (Running / Stopped, with live health check against `/health`)
+- port (default 8787)
+- Start/Stop Proxy: launches `uvx --from git+... opencode-go-proxy` as a child process,
+  writing logs to `~/.codex/logs/opencode-go-proxy.{log,err}` (same paths as the launchd plist)
+- Open Logs / Reveal Log File
+- Copy Port
+- Quit (stops the child proxy first)
+
+## Build
+
+```bash
+cd macos/MenuBarApp
+swift build
+```
+
+Requires macOS 13+ and the Swift toolchain (`xcode-select --install`). This is a SwiftPM
+executable target, so `swift build` works without an Xcode project. To bundle it as a .app:
+
+```bash
+swift build -c release
+cp -R .build/release/OpenCodeGoMenuBar OpenCodeGoMenuBar.app/Contents/MacOS/
+```
+
+## Notes
+
+- The Python bridge is untouched; the app only manages it as a child process.
+- Do not run this app and the launchd agent at the same time: both bind 127.0.0.1:8787 and
+  the second one will fail to bind. Stop the launchd agent first
+  (`launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.opencode-go.proxy.plist`).
+- The proxy resolves the API key exactly as the CLI does: `$OPENCODE_GO_API_KEY` first, then
+  the macOS keychain service `opencode-go-api-key`.

--- a/macos/MenuBarApp/Sources/OpenCodeGoMenuBar/AppDelegate.swift
+++ b/macos/MenuBarApp/Sources/OpenCodeGoMenuBar/AppDelegate.swift
@@ -1,0 +1,121 @@
+import AppKit
+
+final class AppDelegate: NSObject, NSApplicationDelegate {
+    private var statusItem: NSStatusItem!
+    private var proxy = ProxyController()
+    private var statusLabel: NSMenuItem!
+    private var portLabel: NSMenuItem!
+    private var toggleItem: NSMenuItem!
+    private var timer: Timer?
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        NSApp.setActivationPolicy(.accessory)
+
+        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        if let button = statusItem.button {
+            button.image = NSImage(systemSymbolName: "arrow.triangle.branch", accessibilityDescription: "OpenCode Go")
+            button.image?.isTemplate = true
+        }
+        statusItem.menu = buildMenu()
+
+        proxy.onStateChange = { [weak self] in self?.refresh() }
+        refresh()
+        timer = Timer.scheduledTimer(withTimeInterval: 3.0, repeats: true) { [weak self] _ in
+            self?.proxy.refreshHealth()
+        }
+        timer?.tolerance = 1.0
+    }
+
+    private func buildMenu() -> NSMenu {
+        let menu = NSMenu()
+
+        let header = NSMenuItem(title: "OpenCode Go", action: nil, keyEquivalent: "")
+        header.isEnabled = false
+        menu.addItem(header)
+
+        statusLabel = NSMenuItem(title: "", action: nil, keyEquivalent: "")
+        statusLabel.isEnabled = false
+        menu.addItem(statusLabel)
+
+        portLabel = NSMenuItem(title: "", action: nil, keyEquivalent: "")
+        portLabel.isEnabled = false
+        menu.addItem(portLabel)
+
+        menu.addItem(.separator())
+
+        toggleItem = NSMenuItem(title: "Start Proxy", action: #selector(toggleProxy), keyEquivalent: "")
+        toggleItem.target = self
+        menu.addItem(toggleItem)
+
+        let openLogs = NSMenuItem(title: "Open Logs", action: #selector(openLogs), keyEquivalent: "")
+        openLogs.target = self
+        menu.addItem(openLogs)
+
+        let copyPort = NSMenuItem(title: "Copy Port", action: #selector(copyPort), keyEquivalent: "")
+        copyPort.target = self
+        menu.addItem(copyPort)
+
+        let revealLogs = NSMenuItem(title: "Reveal Log File", action: #selector(revealLogs), keyEquivalent: "")
+        revealLogs.target = self
+        menu.addItem(revealLogs)
+
+        menu.addItem(.separator())
+
+        let quit = NSMenuItem(title: "Quit OpenCode Go", action: #selector(quitApp), keyEquivalent: "q")
+        quit.target = self
+        menu.addItem(quit)
+
+        return menu
+    }
+
+    private func refresh() {
+        guard let statusItem, let button = statusItem.button else { return }
+        let state = proxy.state
+        let statusTitle = state.isRunning ? (state.isHealthy ? "Running" : "Starting") : "Stopped"
+
+        let symbol = state.isRunning ? "arrow.triangle.branch.fill" : "arrow.triangle.branch"
+        button.image = NSImage(systemSymbolName: symbol, accessibilityDescription: "OpenCode Go")
+        button.image?.isTemplate = true
+
+        if let statusLabel {
+            statusLabel.title = statusTitle
+        }
+        if let portLabel {
+            portLabel.title = state.isRunning && state.isHealthy ? "Port \(state.port)" : "Port \(state.port) (not listening)"
+        }
+        if let toggleItem {
+            toggleItem.title = state.isRunning ? "Stop Proxy" : "Start Proxy"
+            toggleItem.isEnabled = !state.isStarting
+        }
+    }
+
+    @objc private func toggleProxy() {
+        if proxy.state.isRunning {
+            proxy.stop()
+        } else {
+            proxy.start()
+        }
+        refresh()
+    }
+
+    @objc private func openLogs() {
+        proxy.openLogs()
+    }
+
+    @objc private func copyPort() {
+        proxy.copyPort()
+    }
+
+    @objc private func revealLogs() {
+        proxy.revealLogFile()
+    }
+
+    @objc private func quitApp() {
+        proxy.stop()
+        NSApp.terminate(nil)
+    }
+
+    func applicationWillTerminate(_ notification: Notification) {
+        proxy.stop()
+    }
+}

--- a/macos/MenuBarApp/Sources/OpenCodeGoMenuBar/ProxyController.swift
+++ b/macos/MenuBarApp/Sources/OpenCodeGoMenuBar/ProxyController.swift
@@ -1,0 +1,199 @@
+import AppKit
+import Darwin
+import Foundation
+
+struct ProxyState: Equatable {
+    var isRunning: Bool
+    var isStarting: Bool
+    var isHealthy: Bool
+    var port: Int
+}
+
+final class ProxyController {
+    var onStateChange: (() -> Void)?
+
+    private(set) var state = ProxyState(isRunning: false, isStarting: false, isHealthy: false, port: 8787) {
+        didSet { onStateChange?() }
+    }
+
+    private var childPID: pid_t = -1
+    private var healthURL: URL {
+        URL(string: "http://127.0.0.1:\(state.port)/health")!
+    }
+
+    private var logDir: URL {
+        let base = FileManager.default.homeDirectoryForCurrentUser
+        return base.appendingPathComponent(".codex/logs", isDirectory: true)
+    }
+
+    func start() {
+        guard childPID < 0, !state.isStarting else { return }
+        state = ProxyState(isRunning: false, isStarting: true, isHealthy: false, port: state.port)
+
+        do {
+            try FileManager.default.createDirectory(at: logDir, withIntermediateDirectories: true)
+        } catch {
+            failStart("Could not create log directory: \(error.localizedDescription)")
+            return
+        }
+
+        let logPath = logDir.appendingPathComponent("opencode-go-proxy.log").path
+        let errPath = logDir.appendingPathComponent("opencode-go-proxy.err").path
+        let logFD = open(logPath, O_WRONLY | O_CREAT | O_APPEND, 0o644)
+        let errFD = open(errPath, O_WRONLY | O_CREAT | O_APPEND, 0o644)
+        guard logFD >= 0, errFD >= 0 else {
+            failStart("Could not open log files under \(logDir.path)")
+            return
+        }
+        defer {
+            close(logFD)
+            close(errFD)
+        }
+
+        guard let uvx = findUVX() else {
+            failStart("uvx not found. Install uv (https://docs.astral.sh/uv) or set uvx in PATH.")
+            return
+        }
+
+        let argv: [String] = [
+            uvx,
+            "--from", "git+https://github.com/kartikkabadi/opencode-go-proxy",
+            "opencode-go-proxy",
+            "--bind", "127.0.0.1",
+            "--port", "\(state.port)",
+            "--chat-base-url", "https://opencode.ai/zen/go/v1",
+        ]
+        let pid = spawnInGroup(argv: argv, stdoutFD: logFD, stderrFD: errFD,
+                               env: childEnvironment())
+        guard pid > 0 else {
+            failStart("Could not start proxy (posix_spawn failed).")
+            return
+        }
+
+        childPID = pid
+        state = ProxyState(isRunning: true, isStarting: false, isHealthy: false, port: state.port)
+        monitorChild(pid)
+        refreshHealth()
+    }
+
+    func stop() {
+        guard childPID > 0 else { return }
+        let pid = childPID
+        childPID = -1
+        kill(-pid, SIGTERM)
+        // Grace period, then force-kill the process group if it survives.
+        DispatchQueue.global().asyncAfter(deadline: .now() + 5) {
+            if kill(-pid, 0) == 0 {
+                kill(-pid, SIGKILL)
+            }
+        }
+        state = ProxyState(isRunning: false, isStarting: false, isHealthy: false, port: state.port)
+    }
+
+    func refreshHealth() {
+        var request = URLRequest(url: healthURL)
+        request.timeoutInterval = 1.5
+        URLSession.shared.dataTask(with: request) { [weak self] data, response, _ in
+            let healthy = (response as? HTTPURLResponse)?.statusCode == 200 && data != nil
+            DispatchQueue.main.async {
+                guard let self else { return }
+                let processAlive = self.childPID > 0
+                let next = ProxyState(isRunning: processAlive, isStarting: false,
+                                      isHealthy: processAlive && healthy, port: self.state.port)
+                if next != self.state {
+                    self.state = next
+                }
+            }
+        }.resume()
+    }
+
+    func openLogs() {
+        NSWorkspace.shared.open(logDir)
+    }
+
+    func revealLogFile() {
+        NSWorkspace.shared.activateFileViewerSelecting([logDir.appendingPathComponent("opencode-go-proxy.log")])
+    }
+
+    func copyPort() {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString("\(state.port)", forType: .string)
+    }
+
+    // MARK: - Private
+
+    private func failStart(_ message: String) {
+        state = ProxyState(isRunning: false, isStarting: false, isHealthy: false, port: state.port)
+        presentError(message)
+    }
+
+    private func monitorChild(_ pid: pid_t) {
+        DispatchQueue.global().async {
+            var status: Int32 = 0
+            waitpid(pid, &status, 0)
+            DispatchQueue.main.async {
+                guard self.childPID == pid else { return }
+                self.childPID = -1
+                self.state = ProxyState(isRunning: false, isStarting: false,
+                                        isHealthy: false, port: self.state.port)
+            }
+        }
+    }
+
+    private func spawnInGroup(argv: [String], stdoutFD: Int32, stderrFD: Int32, env: [String]) -> pid_t {
+        var cArgs = argv.map { strdup($0) }
+        cArgs.append(nil)
+        defer { cArgs.forEach { free($0) } }
+
+        var fileActions: posix_spawn_file_actions_t?
+        guard posix_spawn_file_actions_init(&fileActions) == 0 else { return -1 }
+        defer { posix_spawn_file_actions_destroy(&fileActions) }
+        posix_spawn_file_actions_adddup2(&fileActions, stdoutFD, STDOUT_FILENO)
+        posix_spawn_file_actions_adddup2(&fileActions, stderrFD, STDERR_FILENO)
+
+        var attributes: posix_spawnattr_t?
+        guard posix_spawnattr_init(&attributes) == 0 else { return -1 }
+        defer { posix_spawnattr_destroy(&attributes) }
+        posix_spawnattr_setflags(&attributes, Int16(POSIX_SPAWN_SETPGROUP))
+
+        var pid: pid_t = 0
+        let envp = env.map { strdup($0) }
+        defer { envp.forEach { free($0) } }
+        let result = posix_spawn(&pid, cArgs[0], &fileActions, &attributes, &cArgs, envp)
+        return result == 0 ? pid : -1
+    }
+
+    private func childEnvironment() -> [String] {
+        // Menu bar apps launch without the shell PATH; give the child the same
+        // PATH shape as the launchd plist plus a stable HOME.
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        let processInfo = ProcessInfo.processInfo
+        var vars = processInfo.environment
+        vars["HOME"] = home
+        vars["PATH"] = "\(home)/.local/bin:/usr/local/bin:/usr/bin:/bin"
+        vars["PYTHONUNBUFFERED"] = "1"
+        return vars.map { "\($0.key)=\($0.value)" }
+    }
+
+    private func findUVX() -> String? {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        let candidates = [
+            "\(home)/.local/bin/uvx",
+            "/opt/homebrew/bin/uvx",
+            "/usr/local/bin/uvx",
+        ]
+        for candidate in candidates where FileManager.default.isExecutableFile(atPath: candidate) {
+            return candidate
+        }
+        return nil
+    }
+
+    private func presentError(_ message: String) {
+        let alert = NSAlert()
+        alert.messageText = "OpenCode Go Proxy"
+        alert.informativeText = message
+        alert.alertStyle = .warning
+        alert.runModal()
+    }
+}

--- a/macos/MenuBarApp/Sources/OpenCodeGoMenuBar/main.swift
+++ b/macos/MenuBarApp/Sources/OpenCodeGoMenuBar/main.swift
@@ -1,0 +1,6 @@
+import AppKit
+
+let app = NSApplication.shared
+let delegate = AppDelegate()
+app.delegate = delegate
+app.run()

--- a/src/opencode_go_proxy/__main__.py
+++ b/src/opencode_go_proxy/__main__.py
@@ -1,6 +1,5 @@
 from .app import main
 
-
 if __name__ == "__main__":
     main()
 

--- a/src/opencode_go_proxy/app.py
+++ b/src/opencode_go_proxy/app.py
@@ -637,9 +637,14 @@ def main(argv: list[str] | None = None) -> None:
         chat_base_url=config.chat_base_url,
         api_key_env=config.api_key_env,
     )
+    # serve_forever in a background thread: shutdown() from a signal handler
+    # running on the main thread would otherwise deadlock (both need the main
+    # thread), leaving the process unkillable via SIGTERM.
+    serve_thread = threading.Thread(target=server.serve_forever, daemon=True)
     signal.signal(signal.SIGTERM, lambda *_: server.shutdown())
     try:
-        server.serve_forever()
+        serve_thread.start()
+        serve_thread.join()
     except KeyboardInterrupt:
         trace("server.stop", reason="keyboard_interrupt")
     finally:

--- a/src/opencode_go_proxy/app.py
+++ b/src/opencode_go_proxy/app.py
@@ -16,6 +16,7 @@ from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
 
+from . import __version__
 from .protocol import (
     DEFAULT_MODEL,
     IMAGE_MODEL_DEFAULT,
@@ -27,8 +28,6 @@ from .protocol import (
     now_unix,
     responses_payload_to_chat_payload,
 )
-from . import __version__
-
 
 Json = dict[str, Any]
 
@@ -95,7 +94,7 @@ class ResponsesProxyHandler(BaseHTTPRequestHandler):
                 self.end_headers()
                 try:
                     handle_streaming_request(payload, config, request_id, self.wfile)
-                except Exception as exc:
+                except Exception as exc:  # noqa: BLE001 - defensive crash trace
                     trace("request.crashed", request_id=request_id, message=str(exc), traceback=traceback.format_exc())
                     try:
                         err = json.dumps({"type": "response.error", "error": {"message": "proxy crashed; see stderr trace"}}, separators=(",",":")).encode("utf-8")
@@ -111,7 +110,7 @@ class ResponsesProxyHandler(BaseHTTPRequestHandler):
             self._send_json({"error": {"message": exc.message, "type": "proxy_error"}}, status=exc.status)
         except BrokenPipeError:
             trace("client.disconnected", request_id=request_id, message="client closed connection during stream")
-        except Exception as exc:  # pragma: no cover - defensive crash trace
+        except Exception as exc:  # pragma: no cover - defensive crash trace  # noqa: BLE001
             trace("request.crashed", request_id=request_id, message=str(exc), traceback=traceback.format_exc())
             try:
                 self._send_json(

--- a/src/opencode_go_proxy/protocol.py
+++ b/src/opencode_go_proxy/protocol.py
@@ -6,7 +6,6 @@ import time
 import uuid
 from typing import Any
 
-
 Json = dict[str, Any]
 
 DEFAULT_MODEL = "deepseek-v4-flash"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -25,9 +25,8 @@ class CredentialTests(unittest.TestCase):
         app_mod._api_key_cache = None
 
     def test_env_key_wins_without_keychain_lookup(self) -> None:
-        with mock.patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "env-key"}, clear=True):
-            with mock.patch("opencode_go_proxy.app.subprocess.run") as run:
-                self.assertEqual(resolve_api_key(make_config(), "req"), "env-key")
+        with mock.patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "env-key"}, clear=True), mock.patch("opencode_go_proxy.app.subprocess.run") as run:
+            self.assertEqual(resolve_api_key(make_config(), "req"), "env-key")
 
         run.assert_not_called()
 
@@ -38,9 +37,8 @@ class CredentialTests(unittest.TestCase):
             stdout="keychain-key\n",
             stderr="",
         )
-        with mock.patch.dict(os.environ, {}, clear=True):
-            with mock.patch("opencode_go_proxy.app.subprocess.run", return_value=completed):
-                self.assertEqual(resolve_api_key(make_config(), "req"), "keychain-key")
+        with mock.patch.dict(os.environ, {}, clear=True), mock.patch("opencode_go_proxy.app.subprocess.run", return_value=completed):
+            self.assertEqual(resolve_api_key(make_config(), "req"), "keychain-key")
 
     def test_missing_key_names_env_and_keychain(self) -> None:
         completed = subprocess.CompletedProcess(
@@ -49,10 +47,10 @@ class CredentialTests(unittest.TestCase):
             stdout="",
             stderr="could not be found",
         )
-        with mock.patch.dict(os.environ, {}, clear=True):
-            with mock.patch("opencode_go_proxy.app.subprocess.run", return_value=completed):
-                with self.assertRaises(ProxyError) as ctx:
-                    resolve_api_key(make_config(), "req")
+        with mock.patch.dict(os.environ, {}, clear=True), mock.patch(
+            "opencode_go_proxy.app.subprocess.run", return_value=completed
+        ), self.assertRaises(ProxyError) as ctx:
+            resolve_api_key(make_config(), "req")
 
         self.assertEqual(ctx.exception.status, HTTPStatus.UNAUTHORIZED)
         self.assertIn("$OPENCODE_GO_API_KEY", ctx.exception.message)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -4,15 +4,15 @@ import io
 import json
 import os
 import threading
-import urllib.request
 import urllib.error
+import urllib.request
 from http.client import HTTPConnection
+from http.server import ThreadingHTTPServer
 from unittest import mock
 
 import pytest
 
 from opencode_go_proxy.app import ProxyConfig, ResponsesProxyHandler
-from http.server import ThreadingHTTPServer
 
 
 def make_config(port: int) -> ProxyConfig:
@@ -51,8 +51,7 @@ class MockUpstreamResponse:
         return self._body
 
     def __iter__(self):
-        for line in self._lines:
-            yield line
+        yield from self._lines
 
     def __enter__(self):
         return self
@@ -132,15 +131,14 @@ class TestResponsesRoundTrip:
         port, _ = server
         mock_resp = mock_chat_response("hello world")
 
-        with mock.patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "test-key"}):
-            with mock.patch("urllib.request.urlopen", return_value=MockUpstreamResponse(json.dumps(mock_resp).encode())):
-                conn = HTTPConnection("127.0.0.1", port, timeout=5)
-                conn.request("POST", "/v1/responses",
-                             json.dumps({"model": "deepseek-v4-flash", "input": "Say hi."}),
-                             {"content-type": "application/json"})
-                resp = conn.getresponse()
-                body = json.loads(resp.read())
-                conn.close()
+        with mock.patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "test-key"}), mock.patch("urllib.request.urlopen", return_value=MockUpstreamResponse(json.dumps(mock_resp).encode())):
+            conn = HTTPConnection("127.0.0.1", port, timeout=5)
+            conn.request("POST", "/v1/responses",
+                         json.dumps({"model": "deepseek-v4-flash", "input": "Say hi."}),
+                         {"content-type": "application/json"})
+            resp = conn.getresponse()
+            body = json.loads(resp.read())
+            conn.close()
 
         assert resp.status == 200
         assert body["status"] == "completed"
@@ -153,15 +151,14 @@ class TestResponsesRoundTrip:
         port, _ = server
         mock_resp = mock_chat_response("hi")
 
-        with mock.patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "test-key"}):
-            with mock.patch("urllib.request.urlopen", return_value=MockUpstreamResponse(json.dumps(mock_resp).encode())):
-                conn = HTTPConnection("127.0.0.1", port, timeout=5)
-                conn.request("POST", "/responses",
-                             json.dumps({"model": "deepseek-v4-flash", "input": "hi"}),
-                             {"content-type": "application/json"})
-                resp = conn.getresponse()
-                body = json.loads(resp.read())
-                conn.close()
+        with mock.patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "test-key"}), mock.patch("urllib.request.urlopen", return_value=MockUpstreamResponse(json.dumps(mock_resp).encode())):
+            conn = HTTPConnection("127.0.0.1", port, timeout=5)
+            conn.request("POST", "/responses",
+                         json.dumps({"model": "deepseek-v4-flash", "input": "hi"}),
+                         {"content-type": "application/json"})
+            resp = conn.getresponse()
+            body = json.loads(resp.read())
+            conn.close()
 
         assert resp.status == 200
         assert body["status"] == "completed"
@@ -170,15 +167,14 @@ class TestResponsesRoundTrip:
         port, _ = server
         mock_resp = mock_chat_response("compact")
 
-        with mock.patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "test-key"}):
-            with mock.patch("urllib.request.urlopen", return_value=MockUpstreamResponse(json.dumps(mock_resp).encode())):
-                conn = HTTPConnection("127.0.0.1", port, timeout=5)
-                conn.request("POST", "/responses/compact",
-                             json.dumps({"model": "deepseek-v4-flash", "input": "hi"}),
-                             {"content-type": "application/json"})
-                resp = conn.getresponse()
-                body = json.loads(resp.read())
-                conn.close()
+        with mock.patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "test-key"}), mock.patch("urllib.request.urlopen", return_value=MockUpstreamResponse(json.dumps(mock_resp).encode())):
+            conn = HTTPConnection("127.0.0.1", port, timeout=5)
+            conn.request("POST", "/responses/compact",
+                         json.dumps({"model": "deepseek-v4-flash", "input": "hi"}),
+                         {"content-type": "application/json"})
+            resp = conn.getresponse()
+            body = json.loads(resp.read())
+            conn.close()
 
         assert resp.status == 200
         assert body["status"] == "completed"
@@ -191,15 +187,14 @@ class TestResponsesRoundTrip:
         failed_completed = mock.MagicMock()
         failed_completed.returncode = 1
         failed_completed.stdout = ""
-        with mock.patch.dict(os.environ, {}, clear=True):
-            with mock.patch("opencode_go_proxy.app.subprocess.run", return_value=failed_completed):
-                conn = HTTPConnection("127.0.0.1", port, timeout=5)
-                conn.request("POST", "/v1/responses",
-                             json.dumps({"model": "deepseek-v4-flash", "input": "hi"}),
-                             {"content-type": "application/json"})
-                resp = conn.getresponse()
-                body = json.loads(resp.read())
-                conn.close()
+        with mock.patch.dict(os.environ, {}, clear=True), mock.patch("opencode_go_proxy.app.subprocess.run", return_value=failed_completed):
+            conn = HTTPConnection("127.0.0.1", port, timeout=5)
+            conn.request("POST", "/v1/responses",
+                         json.dumps({"model": "deepseek-v4-flash", "input": "hi"}),
+                         {"content-type": "application/json"})
+            resp = conn.getresponse()
+            body = json.loads(resp.read())
+            conn.close()
 
         assert resp.status == 401
         assert "OPENCODE_GO_API_KEY" in body["error"]["message"]
@@ -236,15 +231,14 @@ class TestStreamingResponse:
         ]
         mock_body = b"".join(sse_lines)
 
-        with mock.patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "test-key"}):
-            with mock.patch("urllib.request.urlopen", return_value=MockUpstreamResponse(mock_body)):
-                conn = HTTPConnection("127.0.0.1", port, timeout=10)
-                conn.request("POST", "/v1/responses",
-                             json.dumps({"model": "deepseek-v4-flash", "input": "Say hi.", "stream": True}),
-                             {"content-type": "application/json"})
-                resp = conn.getresponse()
-                raw = resp.read()
-                conn.close()
+        with mock.patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "test-key"}), mock.patch("urllib.request.urlopen", return_value=MockUpstreamResponse(mock_body)):
+            conn = HTTPConnection("127.0.0.1", port, timeout=10)
+            conn.request("POST", "/v1/responses",
+                         json.dumps({"model": "deepseek-v4-flash", "input": "Say hi.", "stream": True}),
+                         {"content-type": "application/json"})
+            resp = conn.getresponse()
+            raw = resp.read()
+            conn.close()
 
         assert resp.status == 200
         assert "text/event-stream" in resp.getheader("content-type", "")
@@ -263,15 +257,14 @@ class TestStreamingResponse:
         failed_completed = mock.MagicMock()
         failed_completed.returncode = 1
         failed_completed.stdout = ""
-        with mock.patch.dict(os.environ, {}, clear=True):
-            with mock.patch("opencode_go_proxy.app.subprocess.run", return_value=failed_completed):
-                conn = HTTPConnection("127.0.0.1", port, timeout=5)
-                conn.request("POST", "/v1/responses",
-                             json.dumps({"model": "deepseek-v4-flash", "input": "hi", "stream": True}),
-                             {"content-type": "application/json"})
-                resp = conn.getresponse()
-                raw = resp.read()
-                conn.close()
+        with mock.patch.dict(os.environ, {}, clear=True), mock.patch("opencode_go_proxy.app.subprocess.run", return_value=failed_completed):
+            conn = HTTPConnection("127.0.0.1", port, timeout=5)
+            conn.request("POST", "/v1/responses",
+                         json.dumps({"model": "deepseek-v4-flash", "input": "hi", "stream": True}),
+                         {"content-type": "application/json"})
+            resp = conn.getresponse()
+            raw = resp.read()
+            conn.close()
 
         assert resp.status == 200
         raw_text = raw.decode("utf-8")
@@ -280,16 +273,17 @@ class TestStreamingResponse:
 
     def test_streaming_crash_sends_sse_error(self, server):
         port, _ = server
-        with mock.patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "test-key"}):
-            with mock.patch("opencode_go_proxy.app.responses_payload_to_chat_payload",
-                            side_effect=ValueError("boom")):
-                conn = HTTPConnection("127.0.0.1", port, timeout=5)
-                conn.request("POST", "/v1/responses",
-                             json.dumps({"model": "deepseek-v4-flash", "input": "hi", "stream": True}),
-                             {"content-type": "application/json"})
-                resp = conn.getresponse()
-                raw = resp.read()
-                conn.close()
+        with mock.patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "test-key"}), mock.patch(
+            "opencode_go_proxy.app.responses_payload_to_chat_payload",
+            side_effect=ValueError("boom"),
+        ):
+            conn = HTTPConnection("127.0.0.1", port, timeout=5)
+            conn.request("POST", "/v1/responses",
+                         json.dumps({"model": "deepseek-v4-flash", "input": "hi", "stream": True}),
+                         {"content-type": "application/json"})
+            resp = conn.getresponse()
+            raw = resp.read()
+            conn.close()
 
         assert resp.status == 200
         raw_text = raw.decode("utf-8")
@@ -302,15 +296,14 @@ class TestEdgeCases:
         port, _ = server
         mock_resp = mock_chat_response("ok")
 
-        with mock.patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "test-key"}):
-            with mock.patch("urllib.request.urlopen", return_value=MockUpstreamResponse(json.dumps(mock_resp).encode())):
-                conn = HTTPConnection("127.0.0.1", port, timeout=5)
-                conn.request("POST", "/v1/responses",
-                             json.dumps({"input": "hi"}),
-                             {"content-type": "application/json"})
-                resp = conn.getresponse()
-                body = json.loads(resp.read())
-                conn.close()
+        with mock.patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "test-key"}), mock.patch("urllib.request.urlopen", return_value=MockUpstreamResponse(json.dumps(mock_resp).encode())):
+            conn = HTTPConnection("127.0.0.1", port, timeout=5)
+            conn.request("POST", "/v1/responses",
+                         json.dumps({"input": "hi"}),
+                         {"content-type": "application/json"})
+            resp = conn.getresponse()
+            body = json.loads(resp.read())
+            conn.close()
 
         assert resp.status == 200
         assert body["status"] == "completed"
@@ -322,15 +315,14 @@ class TestEdgeCases:
             {}, io.BytesIO(b'{"error":"server error"}'),
         )
 
-        with mock.patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "test-key"}):
-            with mock.patch("urllib.request.urlopen", side_effect=err):
-                conn = HTTPConnection("127.0.0.1", port, timeout=5)
-                conn.request("POST", "/v1/responses",
-                             json.dumps({"model": "deepseek-v4-flash", "input": "hi"}),
-                             {"content-type": "application/json"})
-                resp = conn.getresponse()
-                body = json.loads(resp.read())
-                conn.close()
+        with mock.patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "test-key"}), mock.patch("urllib.request.urlopen", side_effect=err):
+            conn = HTTPConnection("127.0.0.1", port, timeout=5)
+            conn.request("POST", "/v1/responses",
+                         json.dumps({"model": "deepseek-v4-flash", "input": "hi"}),
+                         {"content-type": "application/json"})
+            resp = conn.getresponse()
+            body = json.loads(resp.read())
+            conn.close()
 
         assert resp.status == 502
         assert "proxy_error" in body["error"]["type"]
@@ -339,15 +331,14 @@ class TestEdgeCases:
         port, _ = server
         err = urllib.error.URLError("timed out")
 
-        with mock.patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "test-key"}):
-            with mock.patch("urllib.request.urlopen", side_effect=err):
-                conn = HTTPConnection("127.0.0.1", port, timeout=5)
-                conn.request("POST", "/v1/responses",
-                             json.dumps({"model": "deepseek-v4-flash", "input": "hi"}),
-                             {"content-type": "application/json"})
-                resp = conn.getresponse()
-                body = json.loads(resp.read())
-                conn.close()
+        with mock.patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "test-key"}), mock.patch("urllib.request.urlopen", side_effect=err):
+            conn = HTTPConnection("127.0.0.1", port, timeout=5)
+            conn.request("POST", "/v1/responses",
+                         json.dumps({"model": "deepseek-v4-flash", "input": "hi"}),
+                         {"content-type": "application/json"})
+            resp = conn.getresponse()
+            body = json.loads(resp.read())
+            conn.close()
 
         assert resp.status == 502
         assert "network error" in body["error"]["message"].lower()
@@ -359,15 +350,14 @@ class TestEdgeCases:
             {"retry-after": "10"}, io.BytesIO(b'{"error":"rate limited"}'),
         )
 
-        with mock.patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "test-key"}):
-            with mock.patch("urllib.request.urlopen", side_effect=err):
-                conn = HTTPConnection("127.0.0.1", port, timeout=5)
-                conn.request("POST", "/v1/responses",
-                             json.dumps({"model": "deepseek-v4-flash", "input": "hi"}),
-                             {"content-type": "application/json"})
-                resp = conn.getresponse()
-                body = json.loads(resp.read())
-                conn.close()
+        with mock.patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "test-key"}), mock.patch("urllib.request.urlopen", side_effect=err):
+            conn = HTTPConnection("127.0.0.1", port, timeout=5)
+            conn.request("POST", "/v1/responses",
+                         json.dumps({"model": "deepseek-v4-flash", "input": "hi"}),
+                         {"content-type": "application/json"})
+            resp = conn.getresponse()
+            body = json.loads(resp.read())
+            conn.close()
 
         assert resp.status == 429
         assert "retry after" in body["error"]["message"].lower()
@@ -376,30 +366,28 @@ class TestEdgeCases:
         port, _ = server
         mock_resp = mock_chat_response("")
 
-        with mock.patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "test-key"}):
-            with mock.patch("urllib.request.urlopen", return_value=MockUpstreamResponse(json.dumps(mock_resp).encode())):
-                conn = HTTPConnection("127.0.0.1", port, timeout=5)
-                conn.request("POST", "/v1/responses",
-                             json.dumps({"model": "deepseek-v4-flash", "input": ""}),
-                             {"content-type": "application/json"})
-                resp = conn.getresponse()
-                body = json.loads(resp.read())
-                conn.close()
+        with mock.patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "test-key"}), mock.patch("urllib.request.urlopen", return_value=MockUpstreamResponse(json.dumps(mock_resp).encode())):
+            conn = HTTPConnection("127.0.0.1", port, timeout=5)
+            conn.request("POST", "/v1/responses",
+                         json.dumps({"model": "deepseek-v4-flash", "input": ""}),
+                         {"content-type": "application/json"})
+            resp = conn.getresponse()
+            body = json.loads(resp.read())
+            conn.close()
 
         assert resp.status == 200
         assert body["status"] == "completed"
 
     def test_upstream_invalid_json_returns_502(self, server):
         port, _ = server
-        with mock.patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "test-key"}):
-            with mock.patch("urllib.request.urlopen", return_value=MockUpstreamResponse(b"not json")):
-                conn = HTTPConnection("127.0.0.1", port, timeout=5)
-                conn.request("POST", "/v1/responses",
-                             json.dumps({"model": "deepseek-v4-flash", "input": "hi"}),
-                             {"content-type": "application/json"})
-                resp = conn.getresponse()
-                body = json.loads(resp.read())
-                conn.close()
+        with mock.patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "test-key"}), mock.patch("urllib.request.urlopen", return_value=MockUpstreamResponse(b"not json")):
+            conn = HTTPConnection("127.0.0.1", port, timeout=5)
+            conn.request("POST", "/v1/responses",
+                         json.dumps({"model": "deepseek-v4-flash", "input": "hi"}),
+                         {"content-type": "application/json"})
+            resp = conn.getresponse()
+            body = json.loads(resp.read())
+            conn.close()
 
         assert resp.status == 502
         assert "invalid JSON" in body["error"]["message"]
@@ -408,10 +396,11 @@ class TestEdgeCases:
 class TestVersionFlag:
     def test_version_flag_prints_version(self):
         import subprocess
+
         from opencode_go_proxy import __version__
         result = subprocess.run(
             ["uv", "run", "opencode-go-proxy", "--version"],
-            capture_output=True, text=True, cwd=os.path.dirname(os.path.dirname(__file__)),
+            capture_output=True, text=True, check=False, cwd=os.path.dirname(os.path.dirname(__file__)),
         )
         assert result.returncode == 0
         assert __version__ in result.stdout
@@ -458,15 +447,14 @@ class TestAliasMap:
         port, _ = server
         mock_resp = mock_chat_response("ok", model="deepseek-v4-pro")
 
-        with mock.patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "test-key"}):
-            with mock.patch("urllib.request.urlopen", return_value=MockUpstreamResponse(json.dumps(mock_resp).encode())) as mock_urlopen:
-                conn = HTTPConnection("127.0.0.1", port, timeout=5)
-                conn.request("POST", "/v1/responses",
-                             json.dumps({"model": "gpt-5.5", "input": "hi"}),
-                             {"content-type": "application/json"})
-                resp = conn.getresponse()
-                resp.read()
-                conn.close()
+        with mock.patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "test-key"}), mock.patch("urllib.request.urlopen", return_value=MockUpstreamResponse(json.dumps(mock_resp).encode())) as mock_urlopen:
+            conn = HTTPConnection("127.0.0.1", port, timeout=5)
+            conn.request("POST", "/v1/responses",
+                         json.dumps({"model": "gpt-5.5", "input": "hi"}),
+                         {"content-type": "application/json"})
+            resp = conn.getresponse()
+            resp.read()
+            conn.close()
 
         assert resp.status == 200
         sent_payload = json.loads(mock_urlopen.call_args[0][0].data)
@@ -496,22 +484,21 @@ class TestToolCallRoundTrip:
             "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
         }
 
-        with mock.patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "test-key"}):
-            with mock.patch("urllib.request.urlopen", return_value=MockUpstreamResponse(json.dumps(mock_resp).encode())):
-                conn = HTTPConnection("127.0.0.1", port, timeout=5)
-                conn.request("POST", "/v1/responses",
-                             json.dumps({
-                                 "model": "deepseek-v4-flash",
-                                 "input": "What's the weather in SF?",
-                                 "tools": [{"type": "function", "function": {
-                                     "name": "get_weather",
-                                     "parameters": {"type": "object", "properties": {"city": {"type": "string"}}},
-                                 }}],
-                             }),
-                             {"content-type": "application/json"})
-                resp = conn.getresponse()
-                body = json.loads(resp.read())
-                conn.close()
+        with mock.patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "test-key"}), mock.patch("urllib.request.urlopen", return_value=MockUpstreamResponse(json.dumps(mock_resp).encode())):
+            conn = HTTPConnection("127.0.0.1", port, timeout=5)
+            conn.request("POST", "/v1/responses",
+                         json.dumps({
+                             "model": "deepseek-v4-flash",
+                             "input": "What's the weather in SF?",
+                             "tools": [{"type": "function", "function": {
+                                 "name": "get_weather",
+                                 "parameters": {"type": "object", "properties": {"city": {"type": "string"}}},
+                             }}],
+                         }),
+                         {"content-type": "application/json"})
+            resp = conn.getresponse()
+            body = json.loads(resp.read())
+            conn.close()
 
         assert resp.status == 200
         assert body["status"] == "completed"
@@ -532,15 +519,14 @@ class TestStreamingToolCalls:
         ]
         mock_body = b"".join(sse_lines)
 
-        with mock.patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "test-key"}):
-            with mock.patch("urllib.request.urlopen", return_value=MockUpstreamResponse(mock_body)):
-                conn = HTTPConnection("127.0.0.1", port, timeout=10)
-                conn.request("POST", "/v1/responses",
-                             json.dumps({"model": "deepseek-v4-flash", "input": "read README", "stream": True}),
-                             {"content-type": "application/json"})
-                resp = conn.getresponse()
-                raw = resp.read()
-                conn.close()
+        with mock.patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "test-key"}), mock.patch("urllib.request.urlopen", return_value=MockUpstreamResponse(mock_body)):
+            conn = HTTPConnection("127.0.0.1", port, timeout=10)
+            conn.request("POST", "/v1/responses",
+                         json.dumps({"model": "deepseek-v4-flash", "input": "read README", "stream": True}),
+                         {"content-type": "application/json"})
+            resp = conn.getresponse()
+            raw = resp.read()
+            conn.close()
 
         assert resp.status == 200
         raw_text = raw.decode("utf-8")
@@ -597,24 +583,23 @@ class TestImageCaptioning:
             MockUpstreamResponse(json.dumps(main_resp).encode()),
         ]
 
-        with mock.patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "test-key"}):
-            with mock.patch("urllib.request.urlopen", side_effect=responses):
-                conn = HTTPConnection("127.0.0.1", port, timeout=10)
-                conn.request("POST", "/v1/responses",
-                             json.dumps({
-                                 "model": "deepseek-v4-flash",
-                                 "input": [{"type": "message", "role": "user", "content": [
-                                     {"type": "input_text", "text": "What's in this image?"},
-                                     {"type": "input_image", "image_url": "data:image/png;base64,iVBORw0KGgo="},
-                                 ]}],
-                                 "tools": [{"type": "function", "function": {
-                                     "name": "analyze", "parameters": {"type": "object", "properties": {}},
-                                 }}],
-                             }),
-                             {"content-type": "application/json"})
-                resp = conn.getresponse()
-                body = json.loads(resp.read())
-                conn.close()
+        with mock.patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "test-key"}), mock.patch("urllib.request.urlopen", side_effect=responses):
+            conn = HTTPConnection("127.0.0.1", port, timeout=10)
+            conn.request("POST", "/v1/responses",
+                         json.dumps({
+                             "model": "deepseek-v4-flash",
+                             "input": [{"type": "message", "role": "user", "content": [
+                                 {"type": "input_text", "text": "What's in this image?"},
+                                 {"type": "input_image", "image_url": "data:image/png;base64,iVBORw0KGgo="},
+                             ]}],
+                             "tools": [{"type": "function", "function": {
+                                 "name": "analyze", "parameters": {"type": "object", "properties": {}},
+                             }}],
+                         }),
+                         {"content-type": "application/json"})
+            resp = conn.getresponse()
+            body = json.loads(resp.read())
+            conn.close()
 
         assert resp.status == 200
         assert body["status"] == "completed"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -417,6 +417,42 @@ class TestVersionFlag:
         assert __version__ in result.stdout
 
 
+class TestGracefulShutdown:
+    def test_sigterm_stops_server(self):
+        """SIGTERM must stop the proxy (regression: shutdown() from a main-thread
+        signal handler deadlocked when serve_forever ran on the main thread)."""
+        import signal
+        import socket
+        import subprocess
+        import sys
+        import time
+
+        env = dict(os.environ, OPENCODE_GO_API_KEY="test-key")
+        proc = subprocess.Popen(
+            [sys.executable, "-m", "opencode_go_proxy", "--bind", "127.0.0.1", "--port", "8799"],
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        try:
+            deadline = time.monotonic() + 10
+            while time.monotonic() < deadline:
+                try:
+                    with socket.create_connection(("127.0.0.1", 8799), timeout=1):
+                        break
+                except OSError:
+                    time.sleep(0.2)
+            else:
+                raise AssertionError("proxy did not start listening on 8799")
+
+            proc.send_signal(signal.SIGTERM)
+            proc.wait(timeout=8)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=5)
+
+
 class TestAliasMap:
     def test_gpt_alias_maps_to_deepseek(self, server):
         port, _ = server

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1,8 +1,9 @@
+import unittest
+
 from opencode_go_proxy.protocol import (
     chat_completion_to_response,
     responses_payload_to_chat_payload,
 )
-import unittest
 
 
 class ProtocolTests(unittest.TestCase):


### PR DESCRIPTION
## What

Documentation and title cleanup, no runtime change:

- README: "one HTTP port only" section (the bridge already listens on exactly one `ThreadingHTTPServer`; `--port` / `OPENCODE_GO_PROXY_PORT` already wired and documented), an lsof troubleshooting entry, and how to shorten the provider label shown in the Codex model picker by editing `[model_providers.opencode-go] name` in `~/.codex/config.toml` (that's the source of the long "opencode go/" display string; the catalog display names are already short).
- CHANGELOG entries.

## Verification

- No code touched; existing tests unaffected (45 pass on the menu-bar branch this stacks on or alone on main).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a native macOS menu bar app to start/stop and monitor the `opencode-go-proxy`, and update docs for single-port operation (`OPENCODE_GO_PROXY_PORT`, default 8787) and how to shorten the Codex provider label. Fix SIGTERM shutdown by moving `serve_forever` to a background thread; CHANGELOG updated.

<sup>Written for commit fd2d696adc81c94c2fbb8c75c65c36e99f705804. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kartikkabadi/opencode-go-proxy/pull/2?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

