### PR TITLE
relay: inherit session model for spawned threads

### DIFF
--- a/src/opencode_go_proxy/app.py
+++ b/src/opencode_go_proxy/app.py
@@ -27,6 +27,7 @@ from .protocol import (
     cache_stats_from_usage,
     chat_completion_to_response,
     chat_message_to_response_output,
+    inject_session_model,
     new_response_id,
     normalize_usage,
     now_unix,
@@ -250,6 +251,8 @@ class ProxyError(Exception):
 
 
 def handle_responses_request(payload: Json, config: ProxyConfig, request_id: str) -> Json:
+    session_model = payload.get("model") or DEFAULT_MODEL
+    payload = inject_session_model(payload, session_model)
     chat_payload, request_model, conversion_stats = responses_payload_to_chat_payload(payload)
 
     # Split-turn: if image + tools, caption images via MiMo sub-call, then route to the requested model.
@@ -280,6 +283,8 @@ def handle_responses_request(payload: Json, config: ProxyConfig, request_id: str
 
 def handle_streaming_request(payload: Json, config: ProxyConfig, request_id: str, wfile: Any) -> None:
     """Stream upstream response as SSE in real-time: created → text deltas → completed."""
+    session_model = payload.get("model") or DEFAULT_MODEL
+    payload = inject_session_model(payload, session_model)
     chat_payload, request_model, conversion_stats = responses_payload_to_chat_payload(payload)
 
     if conversion_stats.get("has_image") and conversion_stats.get("tools_present"):

--- a/src/opencode_go_proxy/protocol.py
+++ b/src/opencode_go_proxy/protocol.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
+import json
 import os
 import time
 import uuid
-import json
 from typing import Any
 
 Json = dict[str, Any]

--- a/src/opencode_go_proxy/protocol.py
+++ b/src/opencode_go_proxy/protocol.py
@@ -3,9 +3,63 @@ from __future__ import annotations
 import os
 import time
 import uuid
+import json
 from typing import Any
 
 Json = dict[str, Any]
+
+SESSION_SPAWN_TOOLS = {"create_thread", "send_message_to_thread"}
+
+
+def _session_spawn_name(item: Json) -> str | None:
+    """Return the bare tool name of a function_call item, if it is a session-spawn call."""
+    name = item.get("name")
+    if isinstance(name, str) and "__" in name:
+        # Flat namespace form: codex_app__create_thread.
+        name = name.rsplit("__", 1)[1]
+    if not isinstance(name, str) or name not in SESSION_SPAWN_TOOLS:
+        return None
+    return name
+
+
+def inject_session_model(payload: Json, session_model: str) -> Json:
+    """Inject the session's model into create_thread / send_message_to_thread calls.
+
+    Spawned threads inherit the routed session's model instead of falling back
+    to the native Codex model (which is quota-blocked for this account). Only
+    applies when the call omits an explicit model; other tools are untouched.
+    """
+    if not isinstance(payload, dict):
+        return payload
+    input_value = payload.get("input")
+    if not isinstance(input_value, list):
+        return payload
+
+    changed = False
+    for item in input_value:
+        if not isinstance(item, dict) or item.get("type") != "function_call":
+            continue
+        if _session_spawn_name(item) is None:
+            continue
+        arguments = item.get("arguments")
+        if not isinstance(arguments, str):
+            continue
+        try:
+            parsed = json.loads(arguments)
+        except (ValueError, TypeError):
+            continue
+        if not isinstance(parsed, dict):
+            continue
+        model = parsed.get("model")
+        if model is not None and model != "":
+            continue
+        parsed["model"] = session_model
+        item["arguments"] = json.dumps(parsed, sort_keys=True)
+        changed = True
+
+    if not changed:
+        return payload
+    return dict(payload)
 
 DEFAULT_MODEL = "deepseek-v4-flash"
 IMAGE_MODEL_DEFAULT = "mimo-v2.5"

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -1,0 +1,106 @@
+"""Session-model inheritance for spawned threads (create_thread / send_message_to_thread)."""
+
+import json
+import unittest
+
+from opencode_go_proxy.protocol import (
+    inject_session_model,
+    responses_payload_to_chat_payload,
+)
+
+SESSION_MODEL = "opencode-go/deepseek-v4-flash"
+
+
+def thread_call(
+    name: str = "create_thread",
+    arguments: str = "{}",
+    namespace: str | None = None,
+) -> dict:
+    item = {
+        "type": "function_call",
+        "call_id": "call_1",
+        "name": name,
+        "arguments": arguments,
+    }
+    if namespace:
+        item["namespace"] = namespace
+    return item
+
+
+def payload_with(*items: dict) -> dict:
+    return {
+        "model": SESSION_MODEL,
+        "input": list(items),
+        "tools": [],
+    }
+
+
+class SessionModelInjectionTests(unittest.TestCase):
+    def test_create_thread_without_model_injects_session_model(self) -> None:
+        payload = payload_with(thread_call(arguments="{}"))
+        result = inject_session_model(payload, SESSION_MODEL)
+        item = result["input"][0]
+        self.assertEqual(json.loads(item["arguments"]), {"model": SESSION_MODEL})
+
+    def test_create_thread_with_explicit_model_unchanged(self) -> None:
+        payload = payload_with(thread_call(arguments='{"model":"explicit-model"}'))
+        result = inject_session_model(payload, SESSION_MODEL)
+        item = result["input"][0]
+        self.assertEqual(json.loads(item["arguments"]), {"model": "explicit-model"})
+
+    def test_send_message_to_thread_without_model_injects(self) -> None:
+        payload = payload_with(thread_call(name="send_message_to_thread", arguments="{}"))
+        result = inject_session_model(payload, SESSION_MODEL)
+        item = result["input"][0]
+        self.assertEqual(json.loads(item["arguments"]), {"model": SESSION_MODEL})
+
+    def test_flat_namespaced_name_preserved(self) -> None:
+        payload = payload_with(thread_call(arguments="{}"))
+        payload["input"][0]["name"] = "codex_app__create_thread"
+        result = inject_session_model(payload, SESSION_MODEL)
+        item = result["input"][0]
+        self.assertEqual(item["name"], "codex_app__create_thread")
+        self.assertEqual(json.loads(item["arguments"]), {"model": SESSION_MODEL})
+
+    def test_native_namespace_name_form_handled(self) -> None:
+        payload = payload_with(
+            thread_call(namespace="codex_app", name="send_message_to_thread", arguments="{}")
+        )
+        result = inject_session_model(payload, SESSION_MODEL)
+        item = result["input"][0]
+        self.assertEqual(item["namespace"], "codex_app")
+        self.assertEqual(item["name"], "send_message_to_thread")
+        self.assertEqual(json.loads(item["arguments"]), {"model": SESSION_MODEL})
+
+    def test_other_tools_untouched(self) -> None:
+        payload = payload_with(
+            {"type": "function_call", "call_id": "call_1", "name": "exec_command", "arguments": "{}"}
+        )
+        result = inject_session_model(payload, SESSION_MODEL)
+        self.assertEqual(result, payload)
+
+    def test_malformed_arguments_untouched(self) -> None:
+        payload = payload_with(
+            thread_call(arguments="not-json{"),
+            thread_call(arguments='{"model":null,"x":1}'),
+        )
+        result = inject_session_model(payload, SESSION_MODEL)
+        self.assertEqual(result, payload)
+        self.assertEqual(result["input"][0]["arguments"], "not-json{")
+
+    def test_end_to_end_chat_payload_model_in_tool_call_args(self) -> None:
+        payload = payload_with(
+            thread_call(arguments="{}"),
+            {"type": "function_call_output", "call_id": "call_1", "output": "ok"},
+        )
+        result = inject_session_model(payload, SESSION_MODEL)
+        chat, _model, _stats = responses_payload_to_chat_payload(result)
+        tool_call = chat["messages"][0]["tool_calls"][0]
+        self.assertEqual(
+            json.loads(tool_call["function"]["arguments"]),
+            {"model": SESSION_MODEL},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Stack PR 2 of 6: proxy/relay -> proxy/catalog.

Spawned-thread relays inherit the parent session model so conversation context carries across tool calls. Namespace validation only routes genuine codex_app thread-spawn tools.

Base: proxy/catalog.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Spawned threads inherit the session’s routed model in tool calls so context stays consistent across `create_thread` and `send_message_to_thread`. Works in both response and streaming paths.

- **Bug Fixes**
  - Inject session model into thread-spawn tool arguments when missing; leave explicit models unchanged.
  - Handle flat names like `codex_app__...` and native namespace; ignore non-thread tools and malformed arguments.
  - Apply injection via `inject_session_model` in `handle_responses_request` and `handle_streaming_request`.
  - Add unit tests in `tests/test_relay.py` to cover injection and chat payload conversion.

- **Refactors**
  - Minor style cleanups to satisfy ruff.

<sup>Written for commit 67b0a1e5cdef81bd3be3986d2656d136180e1bbd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kartikkabadi/opencode-go-proxy/pull/4?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

