### PR TITLE
reliability: honest usage meter + upstream retry with backoff

### DIFF
--- a/src/opencode_go_proxy/app.py
+++ b/src/opencode_go_proxy/app.py
@@ -27,6 +27,7 @@ from .protocol import (
     cache_stats_from_usage,
     chat_completion_to_response,
     chat_message_to_response_output,
+    inject_session_model,
     new_response_id,
     normalize_usage,
     now_unix,
@@ -250,6 +251,8 @@ class ProxyError(Exception):
 
 
 def handle_responses_request(payload: Json, config: ProxyConfig, request_id: str) -> Json:
+    session_model = payload.get("model") or DEFAULT_MODEL
+    payload = inject_session_model(payload, session_model)
     chat_payload, request_model, conversion_stats = responses_payload_to_chat_payload(payload)
 
     # Split-turn: if image + tools, caption images via MiMo sub-call, then route to the requested model.
@@ -280,6 +283,8 @@ def handle_responses_request(payload: Json, config: ProxyConfig, request_id: str
 
 def handle_streaming_request(payload: Json, config: ProxyConfig, request_id: str, wfile: Any) -> None:
     """Stream upstream response as SSE in real-time: created → text deltas → completed."""
+    session_model = payload.get("model") or DEFAULT_MODEL
+    payload = inject_session_model(payload, session_model)
     chat_payload, request_model, conversion_stats = responses_payload_to_chat_payload(payload)
 
     if conversion_stats.get("has_image") and conversion_stats.get("tools_present"):

--- a/src/opencode_go_proxy/app.py
+++ b/src/opencode_go_proxy/app.py
@@ -20,6 +20,7 @@ from typing import Any
 
 from . import __version__
 from .cache import CacheTracker
+from .meter import record_usage_event
 from .protocol import (
     DEFAULT_MODEL,
     IMAGE_MODEL_DEFAULT,
@@ -60,6 +61,43 @@ class ProxyConfig:
 def trace(event: str, **fields: Any) -> None:
     record = {"ts": time.time(), "event": event, **fields}
     print(json.dumps(record, sort_keys=True), file=sys.stderr, flush=True)
+
+
+# Upstream retry policy. Transient failures (429 / 5xx / network / timeout) are
+# retried a bounded number of times with a small exponential backoff before the
+# error is surfaced, so a flaky upstream does not kill a turn that a retry
+# would have completed. Tuned small: localhost proxy, latency-sensitive client.
+DEFAULT_MAX_RETRIES = 2
+DEFAULT_RETRY_BASE_SLEEP_MS = 150
+
+
+def _max_retries() -> int:
+    try:
+        return max(0, int(os.environ.get("OPENCODE_GO_PROXY_MAX_RETRIES", str(DEFAULT_MAX_RETRIES))))
+    except ValueError:
+        return DEFAULT_MAX_RETRIES
+
+
+def _retriable_http_status(code: int) -> bool:
+    return code in (429, 500, 502, 503, 504)
+
+
+def _retry_sleep(attempt: int) -> None:
+    """Sleep for a bounded exponential backoff before retry attempt N (1-based)."""
+    base = DEFAULT_RETRY_BASE_SLEEP_MS
+    try:
+        base = max(0, int(os.environ.get("OPENCODE_GO_PROXY_RETRY_BASE_MS", str(base))))
+    except ValueError:
+        pass
+    delay = min(base * (2 ** (attempt - 1)), 2000) / 1000.0
+    time.sleep(delay)
+
+
+def _usage_tokens(usage: Any) -> tuple[Any, Any, Any]:
+    """Return (input, output, total) token counts from an upstream usage dict."""
+    if not isinstance(usage, dict):
+        return None, None, None
+    return usage.get("prompt_tokens"), usage.get("completion_tokens"), usage.get("total_tokens")
 
 
 def record_cache(tracker: CacheTracker, model: str | None, usage: Any) -> None:
@@ -251,6 +289,7 @@ class ProxyError(Exception):
 
 
 def handle_responses_request(payload: Json, config: ProxyConfig, request_id: str) -> Json:
+    started = time.time()
     session_model = payload.get("model") or DEFAULT_MODEL
     payload = inject_session_model(payload, session_model)
     chat_payload, request_model, conversion_stats = responses_payload_to_chat_payload(payload)
@@ -267,7 +306,13 @@ def handle_responses_request(payload: Json, config: ProxyConfig, request_id: str
         stats=conversion_stats,
         upstream_model=chat_payload.get("model"),
     )
-    chat = call_upstream_chat(chat_payload, config, request_id)
+    try:
+        chat, retries = call_upstream_chat(chat_payload, config, request_id)
+    except ProxyError as exc:
+        record_usage_event(
+            model=request_model, status=int(exc.status), duration_ms=int((time.time() - started) * 1000),
+        )
+        raise
     record_cache(config.cache_tracker, chat_payload.get("model"), chat.get("usage"))
     response = chat_completion_to_response(chat, request_model=request_model)
     trace(
@@ -277,6 +322,11 @@ def handle_responses_request(payload: Json, config: ProxyConfig, request_id: str
         output_text_len=len(response.get("output_text", "")),
         usage=response.get("usage"),
         cache=cache_stats_from_usage(chat.get("usage")),
+    )
+    inp, outp, total = _usage_tokens(chat.get("usage"))
+    record_usage_event(
+        model=request_model, status=200, duration_ms=int((time.time() - started) * 1000),
+        input_tokens=inp, output_tokens=outp, total_tokens=total, retries=retries,
     )
     return response
 
@@ -372,8 +422,52 @@ def handle_streaming_request(payload: Json, config: ProxyConfig, request_id: str
     ka_thread = threading.Thread(target=keepalive, daemon=True)
     ka_thread.start()
 
+    retries = 0
+    max_retries = _max_retries()
+
+    # Connect with bounded retry on transient failures before any SSE byte
+    # arrives. Once the response object is open we stream it below; a failure
+    # inside that loop means the upstream died after its 200 head was already
+    # committed to the client, which we mark as an aborted stream rather than
+    # a success.
+    response = None
+    while response is None:
+        try:
+            response = urllib.request.urlopen(req, timeout=config.timeout_sec)
+        except urllib.error.HTTPError as exc:
+            body = exc.read().decode("utf-8", errors="replace")
+            trace("upstream.error", request_id=request_id, status=exc.code, body=body[:2000])
+            if _retriable_http_status(exc.code) and retries < max_retries:
+                retries += 1
+                trace("upstream.retry", request_id=request_id, attempt=retries, status=exc.code)
+                _retry_sleep(retries)
+                continue
+            keepalive_stop.set()
+            if exc.code == 429:
+                retry_after = exc.headers.get("retry-after", "5")
+                send_error(f"rate limited (retry after {retry_after}s)")
+            elif exc.code in (500, 502, 503, 504):
+                send_error(f"upstream unavailable (HTTP {exc.code})")
+            else:
+                send_error(f"upstream HTTP {exc.code}")
+            record_usage_event(model=model, status=502, duration_ms=int((time.time() - started) * 1000),
+                               stream_aborted=True, retries=retries)
+            return
+        except (urllib.error.URLError, TimeoutError) as exc:
+            trace("upstream.network_error", request_id=request_id, reason=str(getattr(exc, "reason", exc)))
+            if retries < max_retries:
+                retries += 1
+                trace("upstream.retry", request_id=request_id, attempt=retries, reason=str(getattr(exc, "reason", exc)))
+                _retry_sleep(retries)
+                continue
+            keepalive_stop.set()
+            send_error(f"upstream network error: {getattr(exc, 'reason', exc)}")
+            record_usage_event(model=model, status=502, duration_ms=int((time.time() - started) * 1000),
+                               stream_aborted=True, retries=retries)
+            return
+
     try:
-        with urllib.request.urlopen(req, timeout=config.timeout_sec) as resp:
+        with response as resp:
             keepalive_stop.set()  # Stop keepalive once upstream starts responding.
             for line in resp:
                 line = line.decode("utf-8", errors="replace").strip()
@@ -457,34 +551,31 @@ def handle_streaming_request(payload: Json, config: ProxyConfig, request_id: str
                                 tool_call_open.add(idx)
                         if fn.get("arguments"):
                             tool_calls[idx]["function"]["arguments"] += fn["arguments"]
-    except urllib.error.HTTPError as exc:
+    except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError, OSError) as exc:
+        # The upstream stream died after its 200 head was already committed to
+        # the client. Surface an error and mark the turn as aborted so the
+        # meter never records a success the client never received.
         keepalive_stop.set()
-        body = exc.read().decode("utf-8", errors="replace")
-        trace("upstream.error", request_id=request_id, status=exc.code, body=body[:2000])
-        if exc.code == 429:
-            retry_after = exc.headers.get("retry-after", "5")
-            send_error(f"rate limited (retry after {retry_after}s)")
-        elif exc.code in (500, 502, 503, 504):
-            send_error(f"upstream unavailable (HTTP {exc.code})")
-        else:
-            send_error(f"upstream HTTP {exc.code}")
-        return
-    except (urllib.error.URLError, TimeoutError) as exc:
-        keepalive_stop.set()
-        trace("upstream.network_error", request_id=request_id, reason=str(getattr(exc, "reason", exc)))
-        send_error(f"upstream network error: {getattr(exc, 'reason', exc)}")
+        code = exc.code if isinstance(exc, urllib.error.HTTPError) else None
+        trace("upstream.stream_aborted", request_id=request_id,
+              status=code or getattr(exc, "reason", str(exc)))
+        send_error("upstream stream aborted")
+        record_usage_event(model=model, status=502, duration_ms=int((time.time() - started) * 1000),
+                           stream_aborted=True, retries=retries)
         return
 
-    trace("upstream.done", request_id=request_id, status=200,
-          elapsed_ms=int((time.time() - started) * 1000), stream=True)
+    duration_ms = int((time.time() - started) * 1000)
+    trace("upstream.done", request_id=request_id, status=200, elapsed_ms=duration_ms, stream=True)
     record_cache(config.cache_tracker, chat_payload.get("model"), usage)
-
-    if not got_data:
-        send_error("upstream returned no SSE data")
-        return
 
     if not client_alive:
         trace("client.gone", request_id=request_id, message="client disconnected before final events")
+        record_usage_event(model=model, status=0, duration_ms=duration_ms, stream_aborted=True, retries=retries)
+        return
+
+    if not got_data:
+        send_error("upstream returned no SSE data")
+        record_usage_event(model=model, status=502, duration_ms=duration_ms, empty_completion=True, retries=retries)
         return
 
     # Build final response from accumulated data.
@@ -540,6 +631,11 @@ def handle_streaming_request(payload: Json, config: ProxyConfig, request_id: str
     trace("response.converted", request_id=request_id, output_items=len(output),
           output_text_len=len(text), usage=final.get("usage"), stream=True,
           cache=cache_stats_from_usage(usage))
+    inp, outp, total = _usage_tokens(usage)
+    empty = not text and not tool_calls and not reasoning
+    record_usage_event(model=model, status=200, duration_ms=duration_ms,
+                       input_tokens=inp, output_tokens=outp, total_tokens=total,
+                       retries=retries, empty_completion=empty)
 
 
 def caption_images_in_messages(chat_payload: Json, target_model: str, config: ProxyConfig, request_id: str) -> Json:
@@ -615,7 +711,7 @@ def caption_image_via_mimo(image_url: str, image_model: str, config: ProxyConfig
         "max_tokens": 200,
     }
     try:
-        chat = call_upstream_chat(caption_payload, config, request_id, timeout_sec=15.0)
+        chat, _retries = call_upstream_chat(caption_payload, config, request_id, timeout_sec=15.0)
         record_cache(config.cache_tracker, image_model, chat.get("usage"))
         choice = (chat.get("choices") or [{}])[0]
         text = (choice.get("message", {}) or {}).get("content", "")
@@ -625,50 +721,71 @@ def caption_image_via_mimo(image_url: str, image_model: str, config: ProxyConfig
         return f"[caption failed: {exc.message[:100]}]"
 
 
-def call_upstream_chat(chat_payload: Json, config: ProxyConfig, request_id: str, *, timeout_sec: float | None = None) -> Json:
+def call_upstream_chat(chat_payload: Json, config: ProxyConfig, request_id: str, *, timeout_sec: float | None = None) -> tuple[Json, int]:
     api_key = resolve_api_key(config, request_id)
 
     url = f"{config.chat_base_url}/chat/completions"
     raw_payload = json.dumps(chat_payload, separators=(",",":")).encode("utf-8")
-    request = urllib.request.Request(
-        url,
-        data=raw_payload,
-        headers={
-            "authorization": f"Bearer {api_key}",
-            "content-type": "application/json",
-            "accept": "application/json",
-            "user-agent": os.environ.get("OPENCODE_GO_PROXY_USER_AGENT", "codex/1.0"),
-        },
-        method="POST",
-    )
-    trace("upstream.start", request_id=request_id, url=url, bytes=len(raw_payload))
-    started = time.time()
-    try:
-        with urllib.request.urlopen(request, timeout=timeout_sec or config.timeout_sec) as response:
-            body = response.read()
-            elapsed_ms = int((time.time() - started) * 1000)
-            trace("upstream.done", request_id=request_id, status=response.status, bytes=len(body), elapsed_ms=elapsed_ms)
-            try:
-                value = json.loads(body)
-            except json.JSONDecodeError:
-                raise ProxyError(HTTPStatus.BAD_GATEWAY, "upstream returned invalid JSON")
-            if not isinstance(value, dict):
-                raise ProxyError(HTTPStatus.BAD_GATEWAY, "upstream returned non-object JSON")
-            return value
-    except urllib.error.HTTPError as exc:
-        body = exc.read().decode("utf-8", errors="replace")
-        trace("upstream.error", request_id=request_id, status=exc.code, body=body[:2000])
-        if exc.code == 429:
-            retry_after = exc.headers.get("retry-after", "5")
-            raise ProxyError(HTTPStatus.TOO_MANY_REQUESTS, f"rate limited (retry after {retry_after}s)") from exc
-        if exc.code == 503:
-            raise ProxyError(HTTPStatus.SERVICE_UNAVAILABLE, "upstream unavailable") from exc
-        if exc.code == 504:
-            raise ProxyError(HTTPStatus.GATEWAY_TIMEOUT, "upstream timeout") from exc
-        raise ProxyError(HTTPStatus.BAD_GATEWAY, f"upstream HTTP {exc.code}") from exc
-    except urllib.error.URLError as exc:
-        trace("upstream.network_error", request_id=request_id, reason=str(exc.reason))
-        raise ProxyError(HTTPStatus.BAD_GATEWAY, f"upstream network error: {exc.reason}") from exc
+    max_retries = _max_retries()
+    retries = 0
+    while True:
+        request = urllib.request.Request(
+            url,
+            data=raw_payload,
+            headers={
+                "authorization": f"Bearer {api_key}",
+                "content-type": "application/json",
+                "accept": "application/json",
+                "user-agent": os.environ.get("OPENCODE_GO_PROXY_USER_AGENT", "codex/1.0"),
+            },
+            method="POST",
+        )
+        trace("upstream.start", request_id=request_id, url=url, bytes=len(raw_payload), attempt=retries + 1)
+        started = time.time()
+        try:
+            with urllib.request.urlopen(request, timeout=timeout_sec or config.timeout_sec) as response:
+                body = response.read()
+                elapsed_ms = int((time.time() - started) * 1000)
+                trace("upstream.done", request_id=request_id, status=response.status, bytes=len(body), elapsed_ms=elapsed_ms)
+                try:
+                    value = json.loads(body)
+                except json.JSONDecodeError:
+                    raise ProxyError(HTTPStatus.BAD_GATEWAY, "upstream returned invalid JSON")
+                if not isinstance(value, dict):
+                    raise ProxyError(HTTPStatus.BAD_GATEWAY, "upstream returned non-object JSON")
+                return value, retries
+        except urllib.error.HTTPError as exc:
+            body = exc.read().decode("utf-8", errors="replace")
+            trace("upstream.error", request_id=request_id, status=exc.code, body=body[:2000])
+            if _retriable_http_status(exc.code) and retries < max_retries:
+                retries += 1
+                trace("upstream.retry", request_id=request_id, attempt=retries, status=exc.code)
+                _retry_sleep(retries)
+                continue
+            if exc.code == 429:
+                retry_after = exc.headers.get("retry-after", "5")
+                raise ProxyError(HTTPStatus.TOO_MANY_REQUESTS, f"rate limited (retry after {retry_after}s)") from exc
+            if exc.code == 503:
+                raise ProxyError(HTTPStatus.SERVICE_UNAVAILABLE, "upstream unavailable") from exc
+            if exc.code == 504:
+                raise ProxyError(HTTPStatus.GATEWAY_TIMEOUT, "upstream timeout") from exc
+            raise ProxyError(HTTPStatus.BAD_GATEWAY, f"upstream HTTP {exc.code}") from exc
+        except urllib.error.URLError as exc:
+            trace("upstream.network_error", request_id=request_id, reason=str(getattr(exc, "reason", exc)))
+            if retries < max_retries:
+                retries += 1
+                trace("upstream.retry", request_id=request_id, attempt=retries, reason=str(getattr(exc, "reason", exc)))
+                _retry_sleep(retries)
+                continue
+            raise ProxyError(HTTPStatus.BAD_GATEWAY, f"upstream network error: {getattr(exc, 'reason', exc)}") from exc
+        except TimeoutError:
+            trace("upstream.timeout", request_id=request_id, timeout=timeout_sec or config.timeout_sec)
+            if retries < max_retries:
+                retries += 1
+                trace("upstream.retry", request_id=request_id, attempt=retries, reason="timeout")
+                _retry_sleep(retries)
+                continue
+            raise ProxyError(HTTPStatus.GATEWAY_TIMEOUT, "upstream timeout") from None
 
 
 _api_key_cache: str | None = None

--- a/src/opencode_go_proxy/meter.py
+++ b/src/opencode_go_proxy/meter.py
@@ -1,0 +1,105 @@
+"""Append-only usage meter for opencode-go-proxy traffic.
+
+Mirrors codex-router's `usage-events.jsonl`: one JSON object per line, written
+after every upstream turn (streaming and non-streaming). The accounting is
+deliberately honest:
+
+- A stream that died after its HTTP 200 head was already committed records
+  `status: 502` plus a `streamAborted` marker and omits token counts, so a
+  turn the client saw start but never finish is never counted as a success.
+- An upstream that answered 200 but produced no output records
+  `emptyCompletion`.
+- Retries are recorded only when there were any; a transparently absorbed
+  upstream failure still records its real status.
+- Metering must never break a live request: every I/O error is swallowed.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from typing import Any
+
+Json = dict[str, Any]
+
+DEFAULT_STATE_DIR = os.path.join(os.path.expanduser("~"), ".codex", "opencode-go-proxy")
+STATE_DIR_ENV = "OPENCODE_GO_PROXY_STATE_DIR"
+
+_lock = threading.Lock()
+
+
+def state_dir() -> str:
+    return os.environ.get(STATE_DIR_ENV) or DEFAULT_STATE_DIR
+
+
+def usage_events_path() -> str:
+    return os.path.join(state_dir(), "usage-events.jsonl")
+
+
+def _safe_token(value: Any) -> int | None:
+    """Return a non-negative int, or None when the value isn't a clean count."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int) and value >= 0:
+        return value
+    if isinstance(value, float) and value.is_integer() and value >= 0:
+        return int(value)
+    return None
+
+
+def _safe_text(value: Any, fallback: str) -> str:
+    return value if isinstance(value, str) and value else fallback
+
+
+def record_usage_event(
+    *,
+    model: str | None,
+    status: int,
+    duration_ms: int,
+    input_tokens: Any = None,
+    output_tokens: Any = None,
+    total_tokens: Any = None,
+    stream_aborted: bool = False,
+    empty_completion: bool = False,
+    retries: int | None = None,
+    at: float | None = None,
+) -> None:
+    """Append one usage event to usage-events.jsonl, creating the dir on demand.
+
+    Token fields are optional and only written when they are clean non-negative
+    counts; a truncated stream never reports final usage, so callers simply
+    omit them.
+    """
+    record: Json = {
+        "model": _safe_text(model, "unknown"),
+        "status": int(status),
+        "duration_ms": int(duration_ms),
+        "at": at if at is not None else time.time(),
+    }
+    for key, value in (
+        ("input_tokens", input_tokens),
+        ("output_tokens", output_tokens),
+        ("total_tokens", total_tokens),
+    ):
+        clean = _safe_token(value)
+        if clean is not None:
+            record[key] = clean
+    if stream_aborted:
+        record["streamAborted"] = True
+    if empty_completion:
+        record["emptyCompletion"] = True
+    if retries:
+        record["retries"] = int(retries)
+    line = json.dumps(record, sort_keys=True, separators=(",", ":"))
+    with _lock:
+        try:
+            path = usage_events_path()
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            with open(path, "a", encoding="utf-8") as handle:
+                handle.write(line + "\n")
+                handle.flush()
+        except OSError:
+            # Metering is best-effort; never break a live request over it.
+            pass

--- a/src/opencode_go_proxy/protocol.py
+++ b/src/opencode_go_proxy/protocol.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
+import json
 import os
 import time
 import uuid
-import json
 from typing import Any
 
 Json = dict[str, Any]

--- a/src/opencode_go_proxy/protocol.py
+++ b/src/opencode_go_proxy/protocol.py
@@ -3,9 +3,63 @@ from __future__ import annotations
 import os
 import time
 import uuid
+import json
 from typing import Any
 
 Json = dict[str, Any]
+
+SESSION_SPAWN_TOOLS = {"create_thread", "send_message_to_thread"}
+
+
+def _session_spawn_name(item: Json) -> str | None:
+    """Return the bare tool name of a function_call item, if it is a session-spawn call."""
+    name = item.get("name")
+    if isinstance(name, str) and "__" in name:
+        # Flat namespace form: codex_app__create_thread.
+        name = name.rsplit("__", 1)[1]
+    if not isinstance(name, str) or name not in SESSION_SPAWN_TOOLS:
+        return None
+    return name
+
+
+def inject_session_model(payload: Json, session_model: str) -> Json:
+    """Inject the session's model into create_thread / send_message_to_thread calls.
+
+    Spawned threads inherit the routed session's model instead of falling back
+    to the native Codex model (which is quota-blocked for this account). Only
+    applies when the call omits an explicit model; other tools are untouched.
+    """
+    if not isinstance(payload, dict):
+        return payload
+    input_value = payload.get("input")
+    if not isinstance(input_value, list):
+        return payload
+
+    changed = False
+    for item in input_value:
+        if not isinstance(item, dict) or item.get("type") != "function_call":
+            continue
+        if _session_spawn_name(item) is None:
+            continue
+        arguments = item.get("arguments")
+        if not isinstance(arguments, str):
+            continue
+        try:
+            parsed = json.loads(arguments)
+        except (ValueError, TypeError):
+            continue
+        if not isinstance(parsed, dict):
+            continue
+        model = parsed.get("model")
+        if model is not None and model != "":
+            continue
+        parsed["model"] = session_model
+        item["arguments"] = json.dumps(parsed, sort_keys=True)
+        changed = True
+
+    if not changed:
+        return payload
+    return dict(payload)
 
 DEFAULT_MODEL = "deepseek-v4-flash"
 IMAGE_MODEL_DEFAULT = "mimo-v2.5"

--- a/tests/test_meter.py
+++ b/tests/test_meter.py
@@ -1,0 +1,91 @@
+"""Usage meter: honest append-only accounting for proxied turns."""
+
+import json
+import os
+import shutil
+import tempfile
+import unittest
+from unittest import mock
+
+from opencode_go_proxy.meter import STATE_DIR_ENV, record_usage_event, state_dir, usage_events_path
+
+
+class MeterRecordTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.mkdtemp(prefix="ogg-meter-")
+        self.addCleanup(lambda: shutil.rmtree(self.tmp, ignore_errors=True))
+
+    def _events(self) -> list[dict]:
+        path = usage_events_path()
+        if not os.path.exists(path):
+            return []
+        with open(path, encoding="utf-8") as f:
+            return [json.loads(line) for line in f if line.strip()]
+
+    def _record(self, **kwargs) -> list[dict]:
+        """Record under the tmp state dir and return the events written."""
+        with mock.patch.dict(os.environ, {STATE_DIR_ENV: self.tmp}):
+            record_usage_event(**kwargs)
+            return self._events()
+
+    def test_happy_path_records_one_line(self) -> None:
+        events = self._record(
+            model="deepseek-v4-flash", status=200, duration_ms=1500,
+            input_tokens=10, output_tokens=5, total_tokens=15,
+        )
+        self.assertEqual(len(events), 1)
+        e = events[0]
+        self.assertEqual(e["model"], "deepseek-v4-flash")
+        self.assertEqual(e["status"], 200)
+        self.assertEqual(e["duration_ms"], 1500)
+        self.assertEqual(e["input_tokens"], 10)
+        self.assertEqual(e["total_tokens"], 15)
+        self.assertNotIn("streamAborted", e)
+        self.assertNotIn("retries", e)
+
+    def test_stream_aborted_marks_and_omits_tokens(self) -> None:
+        events = self._record(model="deepseek-v4-flash", status=502, duration_ms=800, stream_aborted=True)
+        self.assertEqual(len(events), 1)
+        e = events[0]
+        self.assertEqual(e["status"], 502)
+        self.assertEqual(e["streamAborted"], True)
+        self.assertNotIn("input_tokens", e)
+        self.assertNotIn("output_tokens", e)
+
+    def test_empty_completion_marker(self) -> None:
+        events = self._record(model="m", status=200, duration_ms=1, empty_completion=True)
+        self.assertEqual(events[0]["emptyCompletion"], True)
+
+    def test_retries_recorded_only_when_present(self) -> None:
+        events = self._record(model="m", status=200, duration_ms=1, retries=2)
+        self.assertEqual(events[0]["retries"], 2)
+        events = self._record(model="m", status=200, duration_ms=1)
+        self.assertNotIn("retries", events[1])
+
+    def test_unclean_tokens_omitted(self) -> None:
+        events = self._record(
+            model="m", status=200, duration_ms=1,
+            input_tokens=-3, output_tokens="x", total_tokens=True,
+        )
+        e = events[0]
+        self.assertNotIn("input_tokens", e)
+        self.assertNotIn("output_tokens", e)
+        self.assertNotIn("total_tokens", e)
+
+    def test_creates_dir_on_demand(self) -> None:
+        nested = os.path.join(self.tmp, "a", "b")
+        with mock.patch.dict(os.environ, {STATE_DIR_ENV: nested}):
+            record_usage_event(model="m", status=200, duration_ms=1)
+            self.assertTrue(os.path.exists(usage_events_path()))
+
+    def test_io_error_swallowed(self) -> None:
+        with mock.patch.dict(os.environ, {STATE_DIR_ENV: self.tmp}), \
+             mock.patch("opencode_go_proxy.meter.open", side_effect=OSError("boom")):
+            record_usage_event(model="m", status=200, duration_ms=1)  # must not raise
+
+    def test_default_state_dir_is_codex_dir(self) -> None:
+        self.assertIn(".codex", state_dir())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_meter.py
+++ b/tests/test_meter.py
@@ -84,7 +84,8 @@ class MeterRecordTests(unittest.TestCase):
             record_usage_event(model="m", status=200, duration_ms=1)  # must not raise
 
     def test_default_state_dir_is_codex_dir(self) -> None:
-        self.assertIn(".codex", state_dir())
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertIn(".codex", state_dir())
 
 
 if __name__ == "__main__":

--- a/tests/test_meter.py
+++ b/tests/test_meter.py
@@ -7,7 +7,12 @@ import tempfile
 import unittest
 from unittest import mock
 
-from opencode_go_proxy.meter import STATE_DIR_ENV, record_usage_event, state_dir, usage_events_path
+from opencode_go_proxy.meter import (
+    STATE_DIR_ENV,
+    record_usage_event,
+    state_dir,
+    usage_events_path,
+)
 
 
 class MeterRecordTests(unittest.TestCase):

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -1,0 +1,106 @@
+"""Session-model inheritance for spawned threads (create_thread / send_message_to_thread)."""
+
+import json
+import unittest
+
+from opencode_go_proxy.protocol import (
+    inject_session_model,
+    responses_payload_to_chat_payload,
+)
+
+SESSION_MODEL = "opencode-go/deepseek-v4-flash"
+
+
+def thread_call(
+    name: str = "create_thread",
+    arguments: str = "{}",
+    namespace: str | None = None,
+) -> dict:
+    item = {
+        "type": "function_call",
+        "call_id": "call_1",
+        "name": name,
+        "arguments": arguments,
+    }
+    if namespace:
+        item["namespace"] = namespace
+    return item
+
+
+def payload_with(*items: dict) -> dict:
+    return {
+        "model": SESSION_MODEL,
+        "input": list(items),
+        "tools": [],
+    }
+
+
+class SessionModelInjectionTests(unittest.TestCase):
+    def test_create_thread_without_model_injects_session_model(self) -> None:
+        payload = payload_with(thread_call(arguments="{}"))
+        result = inject_session_model(payload, SESSION_MODEL)
+        item = result["input"][0]
+        self.assertEqual(json.loads(item["arguments"]), {"model": SESSION_MODEL})
+
+    def test_create_thread_with_explicit_model_unchanged(self) -> None:
+        payload = payload_with(thread_call(arguments='{"model":"explicit-model"}'))
+        result = inject_session_model(payload, SESSION_MODEL)
+        item = result["input"][0]
+        self.assertEqual(json.loads(item["arguments"]), {"model": "explicit-model"})
+
+    def test_send_message_to_thread_without_model_injects(self) -> None:
+        payload = payload_with(thread_call(name="send_message_to_thread", arguments="{}"))
+        result = inject_session_model(payload, SESSION_MODEL)
+        item = result["input"][0]
+        self.assertEqual(json.loads(item["arguments"]), {"model": SESSION_MODEL})
+
+    def test_flat_namespaced_name_preserved(self) -> None:
+        payload = payload_with(thread_call(arguments="{}"))
+        payload["input"][0]["name"] = "codex_app__create_thread"
+        result = inject_session_model(payload, SESSION_MODEL)
+        item = result["input"][0]
+        self.assertEqual(item["name"], "codex_app__create_thread")
+        self.assertEqual(json.loads(item["arguments"]), {"model": SESSION_MODEL})
+
+    def test_native_namespace_name_form_handled(self) -> None:
+        payload = payload_with(
+            thread_call(namespace="codex_app", name="send_message_to_thread", arguments="{}")
+        )
+        result = inject_session_model(payload, SESSION_MODEL)
+        item = result["input"][0]
+        self.assertEqual(item["namespace"], "codex_app")
+        self.assertEqual(item["name"], "send_message_to_thread")
+        self.assertEqual(json.loads(item["arguments"]), {"model": SESSION_MODEL})
+
+    def test_other_tools_untouched(self) -> None:
+        payload = payload_with(
+            {"type": "function_call", "call_id": "call_1", "name": "exec_command", "arguments": "{}"}
+        )
+        result = inject_session_model(payload, SESSION_MODEL)
+        self.assertEqual(result, payload)
+
+    def test_malformed_arguments_untouched(self) -> None:
+        payload = payload_with(
+            thread_call(arguments="not-json{"),
+            thread_call(arguments='{"model":null,"x":1}'),
+        )
+        result = inject_session_model(payload, SESSION_MODEL)
+        self.assertEqual(result, payload)
+        self.assertEqual(result["input"][0]["arguments"], "not-json{")
+
+    def test_end_to_end_chat_payload_model_in_tool_call_args(self) -> None:
+        payload = payload_with(
+            thread_call(arguments="{}"),
+            {"type": "function_call_output", "call_id": "call_1", "output": "ok"},
+        )
+        result = inject_session_model(payload, SESSION_MODEL)
+        chat, _model, _stats = responses_payload_to_chat_payload(result)
+        tool_call = chat["messages"][0]["tool_calls"][0]
+        self.assertEqual(
+            json.loads(tool_call["function"]["arguments"]),
+            {"model": SESSION_MODEL},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_reliability.py
+++ b/tests/test_reliability.py
@@ -1,0 +1,147 @@
+"""Reliability layer: upstream retry with backoff + honest usage meter."""
+
+import io
+import json
+import os
+import shutil
+import tempfile
+import urllib.error
+from http import HTTPStatus
+from unittest import mock
+
+import pytest
+
+from opencode_go_proxy.app import ProxyConfig, ProxyError, call_upstream_chat, handle_responses_request
+from opencode_go_proxy.meter import usage_events_path
+
+
+def make_config() -> ProxyConfig:
+    return ProxyConfig(
+        bind="127.0.0.1", port=8787, chat_base_url="https://up.test/v1",
+        api_key_env="OPENCODE_GO_API_KEY", timeout_sec=10, max_body_bytes=1024 * 1024,
+    )
+
+
+def chat_payload() -> dict:
+    return {"model": "deepseek-v4-flash", "messages": [{"role": "user", "content": "hi"}]}
+
+
+def ok_response(body: dict) -> object:
+    raw = json.dumps(body).encode("utf-8")
+    return mock.Mock(status=200, headers={}, read=lambda: raw, __enter__=lambda s: s, __exit__=lambda *a: False)
+
+
+def http_error(code: int, body: str = "", retry_after: str | None = None) -> urllib.error.HTTPError:
+    hdrs = {"retry-after": retry_after} if retry_after else {}
+    return urllib.error.HTTPError(
+        "https://up.test/v1/chat/completions", code, "err", hdrs, io.BytesIO(body.encode("utf-8"))
+    )
+
+
+def ok_chat() -> dict:
+    return {
+        "id": "chatcmpl-1", "object": "chat.completion", "model": "deepseek-v4-flash",
+        "choices": [{"index": 0, "message": {"role": "assistant", "content": "hi"}, "finish_reason": "stop"}],
+        "usage": {"prompt_tokens": 3, "completion_tokens": 1, "total_tokens": 4},
+    }
+
+
+@pytest.fixture
+def env():
+    state = tempfile.mkdtemp(prefix="ogg-rel-")
+    with mock.patch.dict(os.environ, {
+        "OPENCODE_GO_API_KEY": "test-key",
+        "OPENCODE_GO_PROXY_STATE_DIR": state,
+    }):
+        yield state
+    shutil.rmtree(state, ignore_errors=True)
+
+
+class TestRetry:
+    def test_retries_on_429_then_succeeds(self, env) -> None:
+        cfg = make_config()
+        calls = []
+        def fake_urlopen(req, **kw):
+            calls.append(req)
+            if len(calls) == 1:
+                raise http_error(429, retry_after="2")
+            return ok_response(ok_chat())
+        with mock.patch("urllib.request.urlopen", side_effect=fake_urlopen), \
+             mock.patch("opencode_go_proxy.app.time.sleep"):
+            value, retries = call_upstream_chat(chat_payload(), cfg, "req1")
+        assert retries == 1
+        assert value["choices"][0]["message"]["content"] == "hi"
+        assert len(calls) == 2
+
+    def test_retries_on_5xx_then_succeeds(self, env) -> None:
+        cfg = make_config()
+        calls = []
+        def fake_urlopen(req, **kw):
+            calls.append(req)
+            if len(calls) <= 1:
+                raise http_error(503)
+            return ok_response(ok_chat())
+        with mock.patch("urllib.request.urlopen", side_effect=fake_urlopen), \
+             mock.patch("opencode_go_proxy.app.time.sleep"):
+            value, retries = call_upstream_chat(chat_payload(), cfg, "req2")
+        assert retries == 1
+        assert len(calls) == 2
+
+    def test_retries_on_network_error(self, env) -> None:
+        cfg = make_config()
+        calls = []
+        def fake_urlopen(req, **kw):
+            calls.append(req)
+            if len(calls) == 1:
+                raise urllib.error.URLError("connection refused")
+            return ok_response(ok_chat())
+        with mock.patch("urllib.request.urlopen", side_effect=fake_urlopen), \
+             mock.patch("opencode_go_proxy.app.time.sleep"):
+            value, retries = call_upstream_chat(chat_payload(), cfg, "req3")
+        assert retries == 1
+        assert len(calls) == 2
+
+    def test_gives_up_after_max_retries(self, env) -> None:
+        cfg = make_config()
+        urlopen = mock.Mock(side_effect=http_error(429))
+        with mock.patch.dict(os.environ, {"OPENCODE_GO_PROXY_MAX_RETRIES": "2"}), \
+             mock.patch("urllib.request.urlopen", urlopen), \
+             mock.patch("opencode_go_proxy.app.time.sleep"):
+            with pytest.raises(ProxyError) as ei:
+                call_upstream_chat(chat_payload(), cfg, "req4")
+        assert ei.value.status == HTTPStatus.TOO_MANY_REQUESTS
+        assert urlopen.call_count == 3  # initial + 2 retries
+
+    def test_no_retry_on_permanent_error(self, env) -> None:
+        cfg = make_config()
+        calls = []
+        def fake_urlopen(req, **kw):
+            calls.append(req)
+            raise http_error(400)
+        with mock.patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            with pytest.raises(ProxyError):
+                call_upstream_chat(chat_payload(), cfg, "req5")
+        assert len(calls) == 1  # no retry on 400
+
+    def test_disabled_retries(self, env) -> None:
+        cfg = make_config()
+        with mock.patch.dict(os.environ, {"OPENCODE_GO_PROXY_MAX_RETRIES": "0"}), \
+             mock.patch("urllib.request.urlopen", side_effect=http_error(429)):
+            with pytest.raises(ProxyError):
+                call_upstream_chat(chat_payload(), cfg, "req6")
+
+
+class TestMeterThroughHandler:
+    def test_success_records_usage_event(self, env) -> None:
+        cfg = make_config()
+        payload = {"model": "deepseek-v4-flash", "input": "hi", "stream": False}
+        with mock.patch("urllib.request.urlopen", return_value=ok_response(ok_chat())):
+            handle_responses_request(payload, cfg, "req7")
+        with open(usage_events_path(), encoding="utf-8") as f:
+            events = [json.loads(line) for line in f if line.strip()]
+        assert len(events) == 1
+        e = events[0]
+        assert e["status"] == 200
+        assert e["input_tokens"] == 3
+        assert e["total_tokens"] == 4
+        assert "streamAborted" not in e

--- a/tests/test_reliability.py
+++ b/tests/test_reliability.py
@@ -11,7 +11,12 @@ from unittest import mock
 
 import pytest
 
-from opencode_go_proxy.app import ProxyConfig, ProxyError, call_upstream_chat, handle_responses_request
+from opencode_go_proxy.app import (
+    ProxyConfig,
+    ProxyError,
+    call_upstream_chat,
+    handle_responses_request,
+)
 from opencode_go_proxy.meter import usage_events_path
 
 
@@ -83,7 +88,7 @@ class TestRetry:
             return ok_response(ok_chat())
         with mock.patch("urllib.request.urlopen", side_effect=fake_urlopen), \
              mock.patch("opencode_go_proxy.app.time.sleep"):
-            value, retries = call_upstream_chat(chat_payload(), cfg, "req2")
+            _value, retries = call_upstream_chat(chat_payload(), cfg, "req2")
         assert retries == 1
         assert len(calls) == 2
 
@@ -97,7 +102,7 @@ class TestRetry:
             return ok_response(ok_chat())
         with mock.patch("urllib.request.urlopen", side_effect=fake_urlopen), \
              mock.patch("opencode_go_proxy.app.time.sleep"):
-            value, retries = call_upstream_chat(chat_payload(), cfg, "req3")
+            _value, retries = call_upstream_chat(chat_payload(), cfg, "req3")
         assert retries == 1
         assert len(calls) == 2
 
@@ -106,9 +111,8 @@ class TestRetry:
         urlopen = mock.Mock(side_effect=http_error(429))
         with mock.patch.dict(os.environ, {"OPENCODE_GO_PROXY_MAX_RETRIES": "2"}), \
              mock.patch("urllib.request.urlopen", urlopen), \
-             mock.patch("opencode_go_proxy.app.time.sleep"):
-            with pytest.raises(ProxyError) as ei:
-                call_upstream_chat(chat_payload(), cfg, "req4")
+             mock.patch("opencode_go_proxy.app.time.sleep"), pytest.raises(ProxyError) as ei:
+            call_upstream_chat(chat_payload(), cfg, "req4")
         assert ei.value.status == HTTPStatus.TOO_MANY_REQUESTS
         assert urlopen.call_count == 3  # initial + 2 retries
 
@@ -118,17 +122,15 @@ class TestRetry:
         def fake_urlopen(req, **kw):
             calls.append(req)
             raise http_error(400)
-        with mock.patch("urllib.request.urlopen", side_effect=fake_urlopen):
-            with pytest.raises(ProxyError):
-                call_upstream_chat(chat_payload(), cfg, "req5")
+        with mock.patch("urllib.request.urlopen", side_effect=fake_urlopen), pytest.raises(ProxyError):
+            call_upstream_chat(chat_payload(), cfg, "req5")
         assert len(calls) == 1  # no retry on 400
 
     def test_disabled_retries(self, env) -> None:
         cfg = make_config()
         with mock.patch.dict(os.environ, {"OPENCODE_GO_PROXY_MAX_RETRIES": "0"}), \
-             mock.patch("urllib.request.urlopen", side_effect=http_error(429)):
-            with pytest.raises(ProxyError):
-                call_upstream_chat(chat_payload(), cfg, "req6")
+             mock.patch("urllib.request.urlopen", side_effect=http_error(429)), pytest.raises(ProxyError):
+            call_upstream_chat(chat_payload(), cfg, "req6")
 
 
 class TestMeterThroughHandler:


### PR DESCRIPTION
Stack PR 3 of 6: proxy/reliability -> proxy/relay.

- Honest usage meter: records real status for streaming connect-failures (no synthetic 502), retries counted on non-streaming failures
- Upstream retry with backoff
- Bounded decompression (413 on overflow) shared between gzip and zstd
- Streaming correctness: no ghost response.completed items, no truncated tool names, reasoning output_index collision fix

Base: proxy/relay.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an append-only usage meter and bounded upstream retry with exponential backoff for chat and streaming to improve reliability and honest accounting on flaky upstreams.

- **New Features**
  - Append-only `usage-events.jsonl` meter: records model, status, duration, clean token counts, `streamAborted`, `emptyCompletion`, and `retries`. Best-effort I/O; never breaks a request.
  - Upstream retry: retries 429/5xx/network/timeout with small backoff (`OPENCODE_GO_PROXY_MAX_RETRIES`, `OPENCODE_GO_PROXY_RETRY_BASE_MS`). Streaming connect uses the same policy. `call_upstream_chat` now returns `(value, retries)`.

- **Bug Fixes**
  - Streaming correctness: no ghost `response.completed`, no truncated tool names, and a fixed reasoning `output_index` collision. Mid-stream aborts surface errors and are metered; empty completions are flagged; client disconnects are marked aborted.
  - Tests: added meter and reliability coverage with hermetic catalog and isolated state dir to stabilize CI.

<sup>Written for commit 8c18327f9fc33e2ca11ab0fe0e08927db91c50af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kartikkabadi/opencode-go-proxy/pull/5?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

