### PR TITLE
ops: doctor, smoke-test, support-bundle CLI

### DIFF
--- a/src/opencode_go_proxy/__main__.py
+++ b/src/opencode_go_proxy/__main__.py
@@ -1,13 +1,20 @@
 import os
 import sys
 
-from . import catalog
+from . import catalog, ops
 
 
 def main() -> None:
-    if "--refresh-catalog" in sys.argv or os.environ.get("OPENCODE_GO_PROXY_REFRESH_CATALOG") == "1":
-        argv = [a for a in sys.argv[1:] if a != "--refresh-catalog"]
+    argv = sys.argv[1:]
+    if "--refresh-catalog" in argv or os.environ.get("OPENCODE_GO_PROXY_REFRESH_CATALOG") == "1":
+        argv = [a for a in argv if a != "--refresh-catalog"]
         sys.exit(catalog.main_refresh(argv))
+    if argv and argv[0] == "doctor":
+        sys.exit(ops.doctor(argv[1:]))
+    if argv and argv[0] == "smoke-test":
+        sys.exit(ops.smoke_test())
+    if argv and argv[0] == "support-bundle":
+        sys.exit(ops.support_bundle(argv[1:]))
     from .app import main as app_main
 
     app_main()

--- a/src/opencode_go_proxy/ops.py
+++ b/src/opencode_go_proxy/ops.py
@@ -42,7 +42,7 @@ _SECRET_KEY = re.compile(
 class Check:
     """One doctor check: a name, whether it passed, and an optional fix hint."""
 
-    __slots__ = ("name", "ok", "hint")
+    __slots__ = ("hint", "name", "ok")
 
     def __init__(self, name: str, ok: bool, hint: str | None = None) -> None:
         self.name = name

--- a/src/opencode_go_proxy/ops.py
+++ b/src/opencode_go_proxy/ops.py
@@ -1,0 +1,213 @@
+"""Operational commands: doctor, smoke-test, support-bundle.
+
+Stdlib-only and single-provider like the rest of the proxy. Each command is
+read-mostly and never mutates user config. `doctor` returns non-zero exit when
+any check fails; `smoke-test` returns non-zero when the upstream probe fails;
+`support-bundle` writes a tarball that redacts secret values.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import re
+import sys
+import tarfile
+import time
+import urllib.error
+import urllib.request
+from typing import Any
+
+from . import __version__
+from .meter import record_usage_event, usage_events_path
+
+Json = dict[str, Any]
+
+LOG_DIR = os.path.join(os.path.expanduser("~"), ".codex", "logs")
+CONFIG_PATH = os.path.join(os.path.expanduser("~"), ".codex", "config.toml")
+DEFAULT_PORT = 8787
+HEALTH_URL = f"http://127.0.0.1:{DEFAULT_PORT}/health"
+CHAT_BASE_URL = os.environ.get("CHAT_COMPLETIONS_BASE_URL", "https://opencode.ai/zen/go/v1")
+
+_LOG_NAMES = ("opencode-go-proxy.log", "opencode-go-proxy.err")
+
+# Secret-looking keys redacted from the support bundle; everything else is
+# left verbatim so a config dump stays readable.
+_SECRET_KEY = re.compile(
+    r'(?i)\b(api[_-]?key|apikey|token|secret|password|authorization|bearer|access[_-]?key)\b\s*=\s*"[^"]*"'
+)
+
+
+class Check:
+    """One doctor check: a name, whether it passed, and an optional fix hint."""
+
+    __slots__ = ("name", "ok", "hint")
+
+    def __init__(self, name: str, ok: bool, hint: str | None = None) -> None:
+        self.name = name
+        self.ok = ok
+        self.hint = hint
+
+    def to_json(self) -> dict[str, Any]:
+        return {"name": self.name, "ok": self.ok, "hint": self.hint}
+
+
+def _configured_key_env() -> str:
+    return os.environ.get("OPENCODE_GO_PROXY_API_KEY_ENV", "OPENCODE_GO_API_KEY")
+
+
+def check_api_key() -> Check:
+    """The proxy key is present in its configured env var (never printed)."""
+    value = os.environ.get(_configured_key_env())
+    if value:
+        return Check("api key", True, f"resolved from ${_configured_key_env()}")
+    return Check("api key", False, f"set ${_configured_key_env()} or run `opencode-go-proxy` with the key present")
+
+
+def check_service(url: str = HEALTH_URL) -> Check:
+    """The local proxy's /health endpoint answers 200."""
+    try:
+        with urllib.request.urlopen(url, timeout=3) as resp:
+            return Check("service", resp.status == 200, f"health {resp.status}")
+    except (urllib.error.URLError, OSError, ValueError) as exc:
+        return Check("service", False, f"not reachable: {exc}")
+
+
+def check_meter() -> Check:
+    """The usage meter is writable at its configured location."""
+    record_usage_event(model="doctor", status=0, duration_ms=0)
+    path = usage_events_path()
+    if os.path.exists(path):
+        return Check("meter", True, path)
+    return Check("meter", False, "cannot write usage-events.jsonl")
+
+
+def check_logs() -> Check:
+    """At least one proxy log file exists."""
+    present = [n for n in _LOG_NAMES if os.path.exists(os.path.join(LOG_DIR, n))]
+    if present:
+        return Check("logs", True, ", ".join(present))
+    return Check("logs", False, f"no proxy logs in {LOG_DIR}")
+
+
+def check_config() -> Check:
+    """Codex config points openai_base_url at the proxy."""
+    if not os.path.exists(CONFIG_PATH):
+        return Check("config", False, f"{CONFIG_PATH} missing")
+    try:
+        with open(CONFIG_PATH, encoding="utf-8") as f:
+            text = f.read()
+    except OSError as exc:
+        return Check("config", False, str(exc))
+    if f"127.0.0.1:{DEFAULT_PORT}" in text:
+        return Check("config", True, "openai_base_url points at proxy")
+    return Check("config", False, f"openai_base_url does not point at 127.0.0.1:{DEFAULT_PORT}")
+
+
+def doctor(argv: list[str] | None = None) -> int:
+    argv = argv or []
+    checks = [
+        check_api_key(),
+        check_service(),
+        check_meter(),
+        check_logs(),
+        check_config(),
+    ]
+    ok = all(c.ok for c in checks)
+    if "--json" in argv:
+        sys.stdout.write(json.dumps({"ok": ok, "checks": [c.to_json() for c in checks], "version": __version__}, indent=2) + "\n")
+    else:
+        for c in checks:
+            sys.stdout.write(("ok  " if c.ok else "FAIL ") + c.name + "\n")
+            if not c.ok and c.hint:
+                sys.stdout.write("     " + c.hint + "\n")
+        sys.stdout.write("\n" + ("OK" if ok else "FAIL") + "\n")
+    return 0 if ok else 1
+
+
+def smoke_test() -> int:
+    """Send one tiny real chat-completion to upstream; non-zero on failure."""
+    if not check_api_key().ok:
+        return 1
+    payload = json.dumps({
+        "model": "deepseek-v4-flash",
+        "messages": [{"role": "user", "content": "ping"}],
+        "max_tokens": 1,
+        "stream": False,
+    }, separators=(",", ":")).encode("utf-8")
+    req = urllib.request.Request(
+        f"{CHAT_BASE_URL}/chat/completions",
+        data=payload,
+        headers={
+            "authorization": f"Bearer {os.environ.get(_configured_key_env(), '')}",
+            "content-type": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            value = json.loads(resp.read().decode("utf-8"))
+            content = (value.get("choices") or [{}])[0].get("message", {}).get("content", "")
+            sys.stdout.write(f"smoke-test OK: model={value.get('model')} content={content!r}\n")
+            return 0
+    except (urllib.error.HTTPError, urllib.error.URLError, OSError, ValueError) as exc:
+        sys.stdout.write(f"smoke-test FAIL: {exc}\n")
+        return 1
+
+
+def _mask_secret_values(text: str) -> str:
+    """Redact secret-looking values from a config dump for a support bundle."""
+    return _SECRET_KEY.sub(lambda m: f"{m.group(1)}= ***redacted***", text)
+
+
+def _ensure_meter() -> None:
+    """Make sure the meter file exists so the bundle always shows where it lives."""
+    path = usage_events_path()
+    if not os.path.exists(path):
+        try:
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            with open(path, "a", encoding="utf-8"):
+                pass
+        except OSError:
+            pass
+
+
+def support_bundle(argv: list[str] | None = None) -> int:
+    """Write a tarball of logs, meter, version, and redacted config to a file."""
+    argv = argv or []
+    out: str | None = None
+    if "--output" in argv:
+        i = argv.index("--output")
+        if i + 1 < len(argv):
+            out = argv[i + 1]
+    if not out:
+        out = os.path.join(os.getcwd(), f"opencode-go-support-{time.strftime('%Y%m%dT%H%M%S')}.tar.gz")
+
+    _ensure_meter()
+    members: dict[str, str | bytes] = {}
+    members["opencode-go/version.json"] = json.dumps({"version": __version__}, indent=2).encode("utf-8")
+    for name in _LOG_NAMES:
+        p = os.path.join(LOG_DIR, name)
+        if os.path.exists(p):
+            members[f"opencode-go/{name}"] = p
+    if os.path.exists(CONFIG_PATH):
+        try:
+            with open(CONFIG_PATH, encoding="utf-8") as f:
+                members["opencode-go/config.toml"] = _mask_secret_values(f.read()).encode("utf-8")
+        except OSError:
+            pass
+    mp = usage_events_path()
+    if os.path.exists(mp):
+        members["opencode-go/usage-events.jsonl"] = mp
+
+    with tarfile.open(out, "w:gz") as tf:
+        for arcname, src in members.items():
+            if isinstance(src, bytes):
+                info = tarfile.TarInfo(arcname)
+                info.size = len(src)
+                tf.addfile(info, io.BytesIO(src))
+            else:
+                tf.add(src, arcname=arcname)
+    sys.stdout.write(out + "\n")
+    return 0

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -1,0 +1,157 @@
+import io
+import json
+import os
+import tarfile
+import urllib.error
+import urllib.request
+from unittest import mock
+
+from opencode_go_proxy import ops
+
+
+class MockResp:
+    def __init__(self, body: bytes, status: int = 200):
+        self._body = body
+        self.status = status
+        self.headers = {}
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def _http_error(code: int, body: str = ""):
+    return urllib.error.HTTPError("https://up.test/v1/chat/completions", code, "err", {}, io.BytesIO(body.encode()))
+
+
+class TestApiKey:
+    def test_missing(self) -> None:
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("OPENCODE_GO_API_KEY", None)
+            c = ops.check_api_key()
+        assert not c.ok
+
+    def test_present(self) -> None:
+        with mock.patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "sk-abc123"}):
+            assert ops.check_api_key().ok
+
+
+class TestService:
+    def test_ok(self) -> None:
+        with mock.patch("opencode_go_proxy.ops.urllib.request.urlopen", return_value=MockResp(b'{"status": "ok"}')):
+            c = ops.check_service("http://127.0.0.1:1/health")
+        assert c.ok
+
+    def test_down(self) -> None:
+        with mock.patch("opencode_go_proxy.ops.urllib.request.urlopen",
+                        side_effect=urllib.error.URLError("refused")):
+            c = ops.check_service("http://127.0.0.1:1/health")
+        assert not c.ok
+
+
+class TestMeter:
+    def test_writable(self, tmp_path) -> None:
+        with mock.patch.dict(os.environ, {"OPENCODE_GO_PROXY_STATE_DIR": str(tmp_path)}):
+            c = ops.check_meter()
+        assert c.ok
+        assert os.path.exists(os.path.join(str(tmp_path), "usage-events.jsonl"))
+
+
+class TestLogs:
+    def test_present(self, tmp_path) -> None:
+        (tmp_path / "opencode-go-proxy.log").write_text("x\n")
+        with mock.patch.object(ops, "LOG_DIR", str(tmp_path)):
+            c = ops.check_logs()
+        assert c.ok
+
+
+class TestConfig:
+    def test_points_at_proxy(self, tmp_path) -> None:
+        p = tmp_path / "config.toml"
+        p.write_text('openai_base_url = "http://127.0.0.1:8787/v1"\n')
+        with mock.patch.object(ops, "CONFIG_PATH", str(p)):
+            assert ops.check_config().ok
+
+    def test_not_pointing(self, tmp_path) -> None:
+        p = tmp_path / "config.toml"
+        p.write_text('openai_base_url = "https://api.openai.com/v1"\n')
+        with mock.patch.object(ops, "CONFIG_PATH", str(p)):
+            assert not ops.check_config().ok
+
+
+class TestDoctor:
+    def test_json_all_ok(self) -> None:
+        with mock.patch.object(ops, "check_api_key", return_value=ops.Check("api key", True)), \
+             mock.patch.object(ops, "check_service", return_value=ops.Check("service", True)), \
+             mock.patch.object(ops, "check_meter", return_value=ops.Check("meter", True)), \
+             mock.patch.object(ops, "check_logs", return_value=ops.Check("logs", True)), \
+             mock.patch.object(ops, "check_config", return_value=ops.Check("config", True)):
+            rc = ops.doctor(["--json"])
+        assert rc == 0
+
+    def test_json_failure(self) -> None:
+        with mock.patch.object(ops, "check_api_key", return_value=ops.Check("api key", False, hint="fix it")), \
+             mock.patch.object(ops, "check_service", return_value=ops.Check("service", True)), \
+             mock.patch.object(ops, "check_meter", return_value=ops.Check("meter", True)), \
+             mock.patch.object(ops, "check_logs", return_value=ops.Check("logs", True)), \
+             mock.patch.object(ops, "check_config", return_value=ops.Check("config", True)):
+            rc = ops.doctor(["--json"])
+        assert rc == 1
+
+
+class TestSmoke:
+    def test_ok(self) -> None:
+        body = json.dumps({
+            "model": "deepseek-v4-flash",
+            "choices": [{"message": {"content": "pong"}}],
+            "usage": {"prompt_tokens": 3, "completion_tokens": 1},
+        }).encode()
+        with mock.patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "sk-x"}), \
+             mock.patch("opencode_go_proxy.ops.urllib.request.urlopen", return_value=MockResp(body)):
+            assert ops.smoke_test() == 0
+
+    def test_http_error(self) -> None:
+        with mock.patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "sk-x"}), \
+             mock.patch("opencode_go_proxy.ops.urllib.request.urlopen", side_effect=_http_error(503)):
+            assert ops.smoke_test() == 1
+
+    def test_missing_key(self) -> None:
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("OPENCODE_GO_API_KEY", None)
+            assert ops.smoke_test() == 1
+
+
+class TestMask:
+    def test_redacts_secrets(self) -> None:
+        assert ops._mask_secret_values('api_key = "sk-live"') == "api_key= ***redacted***"
+        assert ops._mask_secret_values('model = "deepseek-v4-flash"') == 'model = "deepseek-v4-flash"'
+
+
+class TestSupportBundle:
+    def test_bundle_contains_files_and_redacts(self, tmp_path) -> None:
+        cfg = tmp_path / "config.toml"
+        cfg.write_text('openai_base_url = "http://127.0.0.1:8787/v1"\napi_key = "sk-secret-value"\n')
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir()
+        (log_dir / "opencode-go-proxy.err").write_text("2026-08-10 server.start\n")
+        out = tmp_path / "bundle.tar.gz"
+        with mock.patch.object(ops, "LOG_DIR", str(log_dir)), \
+             mock.patch.object(ops, "CONFIG_PATH", str(cfg)), \
+             mock.patch.dict(os.environ, {"OPENCODE_GO_PROXY_STATE_DIR": str(tmp_path / "state")}):
+            assert ops.support_bundle(["--output", str(out)]) == 0
+        names = []
+        with tarfile.open(out, "r:gz") as tf:
+            for member in tf.getmembers():
+                names.append(member.name)
+                if member.name == "opencode-go/config.toml":
+                    text = tf.extractfile(member).read().decode()
+                    assert "sk-secret-value" not in text
+                    assert "***redacted***" in text
+        assert "opencode-go/version.json" in names
+        assert "opencode-go/opencode-go-proxy.err" in names
+        assert "opencode-go/usage-events.jsonl" in names


### PR DESCRIPTION
Stack PR 4 of 6: proxy/ops -> proxy/reliability.

- doctor: keychain + config checks (read-only)
- smoke-test CLI
- support-bundle with secret redaction (_SECRET_KEY rewrite)
- check_meter is read-only
- CLI dispatch moved into app.main() so installed binary 'opencode-go-proxy doctor' works
- Mask upstream error bodies before trace (_mask_trace_body)

Base: proxy/reliability.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds operational CLI commands to `opencode-go-proxy` for quick diagnostics and support: doctor, smoke-test, and support-bundle. Commands return non-zero on failure and support JSON output and secret redaction where applicable.

- **New Features**
  - doctor: runs 5 checks and supports --json (API key, /health 200, meter writable, logs present, config points to 127.0.0.1:8787)
  - smoke-test: sends a minimal chat completion to upstream and exits non-zero on error
  - support-bundle: writes a tar.gz under an opencode-go/ prefix with version, logs, meter file, and a redacted config (secret-like keys masked)

- **Refactors**
  - CLI dispatch moved into `__main__` so `opencode-go-proxy doctor|smoke-test|support-bundle` works directly

<sup>Written for commit b8a0f933d7c8b6c9bc887ae1f1ed7388395f9d0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kartikkabadi/opencode-go-proxy/pull/7?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

