### PR TITLE
skills: 0.2.0 skills pack + review fixes + caption timeout + keepalive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,22 @@
 - `CacheTracker` in `src/cache.py`: thread-safe per-model hit/miss/ratio accounting.
 - Key resolution falls back to `OPENCODE_API_KEY` and the `codex-router-opencode-go`
   keychain service, in addition to `OPENCODE_GO_API_KEY` / `opencode-go-api-key`.
+- Spawned threads inherit the session model: `create_thread` and
+  `send_message_to_thread` function calls get the parent thread's model injected
+  when the caller omits one.
+- Honest usage meter in `src/meter.py`: append-only `usage-events.jsonl` in the state
+  dir with per-turn status, duration, tokens and retries. Truncated streams record
+  `streamAborted` and never count as success; empty completions record
+  `emptyCompletion`. Metering failures never break a live request.
+- Upstream retry with bounded exponential backoff on transient failures
+  (429/5xx/network/timeout), configured via `OPENCODE_GO_PROXY_MAX_RETRIES`
+  (default 2) and `OPENCODE_GO_PROXY_RETRY_BASE_MS`.
+- Ops CLI commands: `opencode-go-proxy doctor` (self-check), `smoke-test` (real
+  upstream probe) and `support-bundle` (namespaced tarball of logs, config and
+  meter, with secret values redacted).
 - Tests: cache parsing (both DeepSeek and OpenAI usage shapes), tracker accounting,
-  `/cache` endpoint, streaming `stream_options`, and cache passthrough to Codex.
+  `/cache` endpoint, streaming `stream_options`, cache passthrough to Codex,
+  meter recording, upstream retry behavior, and the ops commands.
 
 ### Changed
 
@@ -21,12 +35,6 @@
   icon, live health check, start/stop of the proxy as a child process, open logs,
   reveal log file, copy port. Build with `swift build` in `macos/MenuBarApp` (macOS 13+).
 
-### Changed
-
-- README: document that the proxy exposes a single HTTP port (`OPENCODE_GO_PROXY_PORT`,
-  default 8787) with no admin/control channel, how to verify what is listening
-  (`lsof -nP -iTCP:8787 -sTCP:LISTEN`), and how to shorten the Codex provider label
-  (edit `[model_providers.opencode-go] name` in `~/.codex/config.toml`).
 ### Changed
 
 - README: document that the proxy exposes a single HTTP port (`OPENCODE_GO_PROXY_PORT`,
@@ -44,6 +52,10 @@
 - SIGTERM graceful shutdown: `serve_forever` now runs on a background thread so the signal
   handler's `server.shutdown()` no longer deadlocks on the main thread, leaving the process
   unkillable via SIGTERM (launchd/systemd stop, menu bar Stop).
+- WebSocket upgrade requests (Codex desktop app realtime) are answered with an explicit
+  `HTTP/1.1 426 Upgrade Required` instead of the previous HTTP/1.0 404, which surfaced as
+  "WebSocket protocol error: HTTP version must be 1.1 or higher" before the app fell back
+  to HTTP streaming.
 
 ## [0.1.2] - 2026-06-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.2.0] - 2026-08-10
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
 - Ops CLI commands: `opencode-go-proxy doctor` (self-check), `smoke-test` (real
   upstream probe) and `support-bundle` (namespaced tarball of logs, config and
   meter, with secret values redacted).
+- Agent skill `skills/opencode-go-proxy/SKILL.md`: orientation for operating the
+  proxy (start/stop, ops commands, prefix caching, config, reliability).
 - Tests: cache parsing (both DeepSeek and OpenAI usage shapes), tracker accounting,
   `/cache` endpoint, streaming `stream_options`, cache passthrough to Codex,
   meter recording, upstream retry behavior, and the ops commands.
@@ -33,10 +35,8 @@
 
 - Native macOS menu bar app in `macos/MenuBarApp` (Swift/AppKit, SwiftPM): short status
   icon, live health check, start/stop of the proxy as a child process, open logs,
-  reveal log file, copy port. Build with `swift build` in `macos/MenuBarApp` (macOS 13+).
-
-### Changed
-
+  reveal log file, copy port. It refuses to Start when port 8787 is already owned
+  (single-port guard). Build with `swift build` in `macos/MenuBarApp` (macOS 13+).
 - README: document that the proxy exposes a single HTTP port (`OPENCODE_GO_PROXY_PORT`,
   default 8787) with no admin/control channel, how to verify what is listening
   (`lsof -nP -iTCP:8787 -sTCP:LISTEN`), and how to shorten the Codex provider label
@@ -44,6 +44,10 @@
 
 ### Fixed
 
+- zstd request bodies: the Codex desktop app sends `/v1/responses` bodies
+  zstd-compressed whenever it is authenticated; the proxy now decompresses
+  `Content-Encoding: zstd` (and gzip) so the desktop app works. Unsupported
+  encodings return an explicit 400 instead of crashing on a magic byte.
 - Reference catalog `contrib/opencode-go-catalog.json` now ships with the `ModelsCache` wrapper
   (`fetched_at`/`etag`/`client_version`/`models`). Codex 0.142+ desktop app requires all four
   top-level fields — the previous bare `{"models": [...]}` caused the model picker to fall back

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -6,7 +6,7 @@ This repository is published on GitHub as
 ## Release surface
 
 - Package: `opencode-go-proxy`
-- Current version: `0.1.2`
+- Current version: `0.2.0`
 - CLI entry point: `opencode-go-proxy`
 - Python: `>=3.11`
 - Build backend: `uv_build`

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/kartikkabadi/opencode-go-proxy/actions/workflows/ci.yml/badge.svg)](https://github.com/kartikkabadi/opencode-go-proxy/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
-[![Zero deps](https://img.shields.io/badge/dependencies-zero-brightgreen.svg)](#)
+[![Dependencies: zstandard](https://img.shields.io/badge/dependencies-zstandard-blue.svg)](#)
 
 Use your [OpenCode Go](https://opencode.ai/docs/go) subscription in the [Codex app](https://github.com/openai/codex).
 
@@ -15,7 +15,7 @@ Codex app
     │
     │  POST /v1/responses (Responses API)
     ▼
-opencode-go-proxy  ←── localhost:8787, zero deps, stdlib only
+opencode-go-proxy  ←── localhost:8787, one runtime dep (zstandard)
     │
     │  POST /v1/chat/completions (Chat Completions API)
     ▼
@@ -177,6 +177,14 @@ See the [lazycodex docs](https://github.com/code-yeongyu/oh-my-openagent) for se
 - SSRF protection on image URLs (`data:image/` and `https://` only)
 - Configurable body cap, bind address guard, keychain credential resolution
 - Local health and model-list endpoints
+- Prefix caching: byte-stable request prefixes plus `include_usage`, with per-model hit ratio on `/cache`
+- Honest usage meter: append-only `usage-events.jsonl` in the state dir (truncated or empty responses never count as success)
+- Upstream retry with bounded exponential backoff on transient failures (429/5xx/network/timeout)
+- Ops CLI: `doctor` (self-check), `smoke-test` (live upstream probe), `support-bundle` (redacted tarball)
+- Spawned threads inherit the parent session's model (`create_thread` / `send_message_to_thread`)
+- WebSocket upgrade requests answered with `426 Upgrade Required` (desktop app falls back to HTTP streaming)
+- zstd-compressed request bodies decompressed (`Content-Encoding: zstd`; the desktop app sends them)
+- Single-port guard in the menu bar app: refuses Start when 8787 is already owned
 
 ## Prefix caching
 

--- a/macos/MenuBarApp/README.md
+++ b/macos/MenuBarApp/README.md
@@ -35,5 +35,6 @@ cp -R .build/release/OpenCodeGoMenuBar OpenCodeGoMenuBar.app/Contents/MacOS/
   127.0.0.1:8787 (for example the launchd agent), instead of spawning a second proxy that
   would fail to bind. One proxy per port. To switch from launchd to the menu bar, stop the
   launchd agent first (`launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.opencode-go.proxy.plist`).
-- The proxy resolves the API key exactly as the CLI does: `$OPENCODE_GO_API_KEY` first, then
-  the macOS keychain service `opencode-go-api-key`.
+- The spawned proxy resolves the API key exactly as the CLI does: `$OPENCODE_GO_API_KEY`
+  first, then `$OPENCODE_API_KEY`, then the macOS keychain services `opencode-go-api-key`
+  and `codex-router-opencode-go`.

--- a/macos/MenuBarApp/Sources/OpenCodeGoMenuBar/ProxyController.swift
+++ b/macos/MenuBarApp/Sources/OpenCodeGoMenuBar/ProxyController.swift
@@ -51,6 +51,9 @@ final class ProxyController {
         let logFD = open(logPath, O_WRONLY | O_CREAT | O_APPEND, 0o644)
         let errFD = open(errPath, O_WRONLY | O_CREAT | O_APPEND, 0o644)
         guard logFD >= 0, errFD >= 0 else {
+            // Close whatever opened successfully so the failure path leaks no fd.
+            if logFD >= 0 { close(logFD) }
+            if errFD >= 0 { close(errFD) }
             failStart("Could not open log files under \(logDir.path)")
             return
         }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "opencode-go-proxy"
-version = "0.1.2"
+version = "0.2.0"
 description = "Use your OpenCode Go subscription in Codex — local Responses-to-Chat-Completions bridge"
 readme = "README.md"
 authors = [{ name = "Kartik Kabadi", email = "1kartikkabadi1@gmail.com" }]

--- a/skills/opencode-go-proxy/SKILL.md
+++ b/skills/opencode-go-proxy/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: opencode-go-proxy
-description: Orientation for using the opencode-go-proxy bridge, which lets the Codex app use the OpenCode Go subscription (13 open coding models) through a local zero-dependency Python service. Explains how traffic flows, how to start and stop the proxy (menu bar app or CLI, single port 8787), the operational commands (doctor, smoke-test, support-bundle), how prefix caching works and how to check the hit ratio, and the config and API-key resolution. Use when working on or operating opencode-go-proxy, or when the Codex app is pointed at 127.0.0.1:8787.
+description: Orientation for using the opencode-go-proxy bridge, which lets the Codex app use the OpenCode Go subscription (13 open coding models) through a local Python service with one runtime dependency (zstandard). Explains how traffic flows, how to start and stop the proxy (menu bar app or CLI, single port 8787), the operational commands (doctor, smoke-test, support-bundle), how prefix caching works and how to check the hit ratio, and the config and API-key resolution. Use when working on or operating opencode-go-proxy, or when the Codex app is pointed at 127.0.0.1:8787.
 ---
 
 # OpenCode Go Proxy
 
-The proxy bridges Codex's Responses API to OpenCode Go's Chat Completions API in one local process on port 8787. It is stdlib-only, single-provider, and single-port.
+The proxy bridges Codex's Responses API to OpenCode Go's Chat Completions API in one local process on port 8787. It has one runtime dependency (zstandard); the rest is stdlib. It is single-provider and single-port.
 
 ```text
 Codex app -> POST /v1/responses -> opencode-go-proxy (127.0.0.1:8787) -> POST /v1/chat/completions -> OpenCode Go
@@ -42,5 +42,5 @@ Resolved in order: `OPENCODE_GO_API_KEY`, `OPENCODE_API_KEY`, then macOS keychai
 
 ## Config
 
-- `~/.codex/config.toml`: the provider block points `openai_base_url` at `http://127.0.0.1:8787/v1`; the `[model_providers.opencode-go] name` knob controls the label in the Codex model picker.
-- Bind is guarded to localhost; the proxy refuses to expose the upstream API key to the network.
+- `~/.codex/config.toml`: the provider block points `base_url` at `http://127.0.0.1:8787/v1`; the `[model_providers.opencode-go] name` knob controls the label in the Codex model picker.
+- Bind is guarded: the proxy emits a trace-log warning when bound outside localhost (e.g. `--bind 0.0.0.0`). It does not refuse to start.

--- a/skills/opencode-go-proxy/SKILL.md
+++ b/skills/opencode-go-proxy/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: opencode-go-proxy
+description: Orientation for using the opencode-go-proxy bridge, which lets the Codex app use the OpenCode Go subscription (13 open coding models) through a local zero-dependency Python service. Explains how traffic flows, how to start and stop the proxy (menu bar app or CLI, single port 8787), the operational commands (doctor, smoke-test, support-bundle), how prefix caching works and how to check the hit ratio, and the config and API-key resolution. Use when working on or operating opencode-go-proxy, or when the Codex app is pointed at 127.0.0.1:8787.
+---
+
+# OpenCode Go Proxy
+
+The proxy bridges Codex's Responses API to OpenCode Go's Chat Completions API in one local process on port 8787. It is stdlib-only, single-provider, and single-port.
+
+```text
+Codex app -> POST /v1/responses -> opencode-go-proxy (127.0.0.1:8787) -> POST /v1/chat/completions -> OpenCode Go
+```
+
+## Start and stop
+
+- The proxy is controlled by a native macOS menu bar app (branch icon). It shows live status, Start/Stop, logs, and copy-port, and it stops the child proxy on Quit. It refuses to Start if port 8787 is already owned (single-port guard).
+- CLI: `uvx --from git+https://github.com/kartikkabadi/opencode-go-proxy opencode-go-proxy --port 8787`.
+- One proxy per port. Do not run the menu bar app and a launchd agent at the same time; stop the launchd agent first (`launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.opencode.go.proxy.plist`).
+
+## Operational commands
+
+- `opencode-go-proxy doctor` - read-only self-check (API key present, /health 200, meter writable, logs present, Codex config points at the proxy). `--json` for machine output; non-zero exit on any failure.
+- `opencode-go-proxy smoke-test` - one tiny real chat-completion to upstream; non-zero on failure.
+- `opencode-go-proxy support-bundle [--output FILE]` - tarball of version, logs, meter, and redacted config (secret values masked, never bundled raw).
+- `opencode-go-proxy --refresh-catalog` - refresh the model catalog from models.dev.
+
+## Prefix caching
+
+OpenCode Go bills cached reads cheaply, so request prefixes are kept byte-stable: the system prompt is always first, history is appended in order, and streaming sets `stream_options.include_usage` so the upstream reports its cache accounting. First request of a new context always misses (cold); later requests in a session typically hit 99%+.
+
+Check the ratio: `curl http://127.0.0.1:8787/cache` (per-model and totals). Per-request: grep for `"cache"` in the stderr log.
+
+## API key
+
+Resolved in order: `OPENCODE_GO_API_KEY`, `OPENCODE_API_KEY`, then macOS keychain services `opencode-go-api-key` and `codex-router-opencode-go`. Never print or commit the key.
+
+## Reliability
+
+- Truncated streams are never counted as success: the meter (`usage-events.jsonl`) records `streamAborted` with status 502.
+- Transient upstream failures (429/5xx/network/timeout) are retried with bounded backoff (`OPENCODE_GO_PROXY_MAX_RETRIES`, default 2) before surfacing an error.
+- The WebSocket upgrade the Codex desktop app attempts for realtime is answered with `HTTP/1.1 426`; the app falls back to HTTP streaming. That is by design, not an error.
+
+## Config
+
+- `~/.codex/config.toml`: the provider block points `openai_base_url` at `http://127.0.0.1:8787/v1`; the `[model_providers.opencode-go] name` knob controls the label in the Codex model picker.
+- Bind is guarded to localhost; the proxy refuses to expose the upstream API key to the network.

--- a/src/opencode_go_proxy/__init__.py
+++ b/src/opencode_go_proxy/__init__.py
@@ -2,5 +2,5 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.1.2"
+__version__ = "0.2.0"
 

--- a/src/opencode_go_proxy/__main__.py
+++ b/src/opencode_go_proxy/__main__.py
@@ -1,24 +1,6 @@
-import os
 import sys
 
-from . import catalog, ops
-
-
-def main() -> None:
-    argv = sys.argv[1:]
-    if "--refresh-catalog" in argv or os.environ.get("OPENCODE_GO_PROXY_REFRESH_CATALOG") == "1":
-        argv = [a for a in argv if a != "--refresh-catalog"]
-        sys.exit(catalog.main_refresh(argv))
-    if argv and argv[0] == "doctor":
-        sys.exit(ops.doctor(argv[1:]))
-    if argv and argv[0] == "smoke-test":
-        sys.exit(ops.smoke_test())
-    if argv and argv[0] == "support-bundle":
-        sys.exit(ops.support_bundle(argv[1:]))
-    from .app import main as app_main
-
-    app_main()
-
+from .app import main
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/src/opencode_go_proxy/app.py
+++ b/src/opencode_go_proxy/app.py
@@ -90,6 +90,18 @@ def trace(event: str, **fields: Any) -> None:
 DEFAULT_MAX_RETRIES = 2
 DEFAULT_RETRY_BASE_SLEEP_MS = 150
 
+# Budget for the MiMo image-caption sub-call. Generous on purpose: a healthy
+# caption call routinely takes ~16s, and the sub-call degrades to a placeholder
+# on timeout rather than crashing the turn.
+DEFAULT_CAPTION_TIMEOUT_SEC = 60.0
+
+
+def _caption_timeout_sec() -> float:
+    try:
+        return max(1.0, float(os.environ.get("OPENCODE_GO_PROXY_CAPTION_TIMEOUT_SEC", str(DEFAULT_CAPTION_TIMEOUT_SEC))))
+    except ValueError:
+        return DEFAULT_CAPTION_TIMEOUT_SEC
+
 
 def _max_retries() -> int:
     try:
@@ -785,7 +797,7 @@ def caption_image_via_mimo(image_url: str, image_model: str, config: ProxyConfig
         "max_tokens": 200,
     }
     try:
-        chat, _retries = call_upstream_chat(caption_payload, config, request_id, timeout_sec=15.0)
+        chat, _retries = call_upstream_chat(caption_payload, config, request_id, timeout_sec=_caption_timeout_sec())
         record_cache(config.cache_tracker, image_model, chat.get("usage"))
         choice = (chat.get("choices") or [{}])[0]
         text = (choice.get("message", {}) or {}).get("content", "")

--- a/src/opencode_go_proxy/app.py
+++ b/src/opencode_go_proxy/app.py
@@ -384,6 +384,27 @@ def handle_streaming_request(payload: Json, config: ProxyConfig, request_id: str
     payload = inject_session_model(payload, session_model)
     chat_payload, request_model, conversion_stats = responses_payload_to_chat_payload(payload)
 
+    client_alive = True
+
+    # Keepalive: send SSE comments every 15s while waiting for upstream first
+    # byte. Prevents Codex from timing out when the model thinks for 30+
+    # seconds before responding. Started before the image-caption sub-call so
+    # the client never sees a silent open stream while a caption is fetched.
+    keepalive_stop = threading.Event()
+
+    def keepalive() -> None:
+        while not keepalive_stop.wait(15):
+            if not client_alive:
+                return
+            try:
+                wfile.write(b": keepalive\n\n")
+                wfile.flush()
+            except BrokenPipeError:
+                return
+
+    ka_thread = threading.Thread(target=keepalive, daemon=True)
+    ka_thread.start()
+
     if conversion_stats.get("has_image") and conversion_stats.get("tools_present"):
         chat_payload = caption_images_in_messages(chat_payload, request_model, config, request_id)
         conversion_stats["upstream_model"] = chat_payload.get("model")
@@ -399,8 +420,6 @@ def handle_streaming_request(payload: Json, config: ProxyConfig, request_id: str
 
     response_id = new_response_id()
     model = request_model or DEFAULT_MODEL
-
-    client_alive = True
 
     def send_event(event: Json) -> None:
         nonlocal client_alive
@@ -486,23 +505,10 @@ def handle_streaming_request(payload: Json, config: ProxyConfig, request_id: str
                     "output_index": (1 if reasoning_emitted else 0) + idx, "item": tc_item})
         tool_call_open.add(idx)
 
-    # Keepalive: send SSE comments every 15s while waiting for upstream first byte.
-    # Prevents Codex from timing out when the model thinks for 30+ seconds before responding.
-    keepalive_stop = threading.Event()
-
-    def keepalive() -> None:
-        while not keepalive_stop.wait(15):
-            if not client_alive:
-                return
-            try:
-                wfile.write(b": keepalive\n\n")
-                wfile.flush()
-            except BrokenPipeError:
-                return
-
-    ka_thread = threading.Thread(target=keepalive, daemon=True)
-    ka_thread.start()
-
+    # Keepalive: send SSE comments every 15s while waiting for upstream first
+    # byte. Prevents Codex from timing out when the model thinks for 30+
+    # seconds before responding. Started before the image-caption sub-call so
+    # the client never sees a silent open stream while a caption is fetched.
     retries = 0
     max_retries = _max_retries()
 

--- a/src/opencode_go_proxy/app.py
+++ b/src/opencode_go_proxy/app.py
@@ -199,7 +199,7 @@ def decode_request_body(raw: bytes, content_encoding: str, max_body_bytes: int) 
                 return _decompress_bounded(reader, cap)
         except ProxyError:
             raise
-        except Exception as exc:  # noqa: BLE001 - surface a clean 400, not a crash
+        except Exception as exc:
             raise ProxyError(HTTPStatus.BAD_REQUEST, f"failed to decompress gzip request body: {exc}") from exc
     raise ProxyError(HTTPStatus.BAD_REQUEST, f"unsupported content-encoding: {content_encoding}")
 

--- a/src/opencode_go_proxy/app.py
+++ b/src/opencode_go_proxy/app.py
@@ -5,6 +5,7 @@ import gzip
 import io
 import json
 import os
+import re
 import signal
 import subprocess
 import sys
@@ -36,6 +37,25 @@ from .protocol import (
 )
 
 Json = dict[str, Any]
+
+# Secret-looking content masked out of upstream error bodies before they are
+# traced to stderr (and later shipped in a support bundle). An upstream that
+# echoes the request Authorization header back in its error body would
+# otherwise leak the API key into logs verbatim.
+_MASK_RE = re.compile(
+    r"(?i)(authorization[\s\"']*[:=][\s\"']*)[^\"'\r\n,;]+|(\bsk-[A-Za-z0-9_\-]{8,}\b)"
+)
+
+
+def _mask_trace_body(body: str, limit: int = 2000) -> str:
+    text = body[:limit]
+
+    def _repl(m: re.Match) -> str:
+        if m.group(1):
+            return f"{m.group(1)}<redacted>"
+        return "<redacted>"
+
+    return _MASK_RE.sub(_repl, text)
 
 
 class ProxyConfig:
@@ -108,6 +128,29 @@ def record_cache(tracker: CacheTracker, model: str | None, usage: Any) -> None:
     tracker.record(model or "unknown", stats["hit"], stats["miss"])
 
 
+def _decompress_bounded(reader: Any, cap: int) -> bytes:
+    """Read `reader` in chunks, raising 413 once the output exceeds `cap`.
+
+    Both zstd and gzip frames can declare an output size that is only a hint,
+    so a zip bomb must be bounded by counting bytes as they come out, never by
+    trusting the frame header or decompressing the whole body at once.
+    """
+    chunks: list[bytes] = []
+    total = 0
+    while True:
+        chunk = reader.read(1 << 16)
+        if not chunk:
+            break
+        total += len(chunk)
+        if total > cap:
+            raise ProxyError(
+                HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
+                "decompressed request body exceeds the size cap",
+            )
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
 def decode_request_body(raw: bytes, content_encoding: str, max_body_bytes: int) -> bytes:
     """Decode an HTTP request body according to its Content-Encoding header.
 
@@ -129,33 +172,23 @@ def decode_request_body(raw: bytes, content_encoding: str, max_body_bytes: int) 
             ) from exc
         cap = max(max_body_bytes * 4, 1 << 20)
         try:
-            # Stream-decompress with a hard output cap: zstandard's
-            # max_output_size is only a hint once the frame declares its size,
-            # so a zip bomb must be bounded by reading in chunks and counting.
-            chunks: list[bytes] = []
-            total = 0
             with zstd.ZstdDecompressor().stream_reader(io.BytesIO(raw)) as reader:
-                while True:
-                    chunk = reader.read(1 << 16)
-                    if not chunk:
-                        break
-                    total += len(chunk)
-                    if total > cap:
-                        raise ProxyError(
-                            HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
-                            "decompressed request body exceeds the size cap",
-                        )
-                    chunks.append(chunk)
-            return b"".join(chunks)
+                return _decompress_bounded(reader, cap)
         except ProxyError:
             raise
         except Exception as exc:
             raise ProxyError(HTTPStatus.BAD_REQUEST, f"failed to decompress zstd request body: {exc}") from exc
     if encoding in {"gzip", "x-gzip"}:
+        # Same bounded decompression as zstd: a tiny gzip wire body must not be
+        # able to balloon into a multi-GB allocation (gzip.decompress has no cap).
+        cap = max(max_body_bytes * 4, 1 << 20)
         try:
-            return gzip.decompress(raw)
-        except OSError as exc:
-            raise ProxyError(HTTPStatus.BAD_REQUEST, "failed to decompress gzip request body") from exc
+            with gzip.GzipFile(fileobj=io.BytesIO(raw)) as reader:
+                return _decompress_bounded(reader, cap)
+        except ProxyError:
+            raise
+        except Exception as exc:  # noqa: BLE001 - surface a clean 400, not a crash
+            raise ProxyError(HTTPStatus.BAD_REQUEST, f"failed to decompress gzip request body: {exc}") from exc
     raise ProxyError(HTTPStatus.BAD_REQUEST, f"unsupported content-encoding: {content_encoding}")
 
 
@@ -282,10 +315,11 @@ class ResponsesProxyHandler(BaseHTTPRequestHandler):
 
 
 class ProxyError(Exception):
-    def __init__(self, status: HTTPStatus, message: str) -> None:
+    def __init__(self, status: HTTPStatus, message: str, *, retries: int = 0) -> None:
         super().__init__(message)
         self.status = status
         self.message = message
+        self.retries = retries
 
 
 def handle_responses_request(payload: Json, config: ProxyConfig, request_id: str) -> Json:
@@ -311,6 +345,7 @@ def handle_responses_request(payload: Json, config: ProxyConfig, request_id: str
     except ProxyError as exc:
         record_usage_event(
             model=request_model, status=int(exc.status), duration_ms=int((time.time() - started) * 1000),
+            retries=exc.retries or None,
         )
         raise
     record_cache(config.cache_tracker, chat_payload.get("model"), chat.get("usage"))
@@ -403,7 +438,41 @@ def handle_streaming_request(payload: Json, config: ProxyConfig, request_id: str
     reasoning_id = f"rs_{uuid.uuid4().hex}"
     item_open = False
     reasoning_open = False
+    # reasoning_emitted is set the moment the reasoning item is opened and never
+    # cleared: every later item's output_index is computed from it, so a
+    # reasoning item that is already closed still occupies output_index 0 and
+    # text/tool calls cannot collide with it.
+    reasoning_emitted = False
     got_data = False
+
+    def emit_tool_added(idx: int) -> None:
+        """Emit output_item.added for tool call `idx` with its complete name.
+
+        The upstream streams tool names in chunks (e.g. 'read_' then 'file'),
+        so added must be deferred until the name is complete. The stream moves
+        on to the arguments phase only after the final name chunk, so the first
+        arguments delta is the signal that the name is complete; tool calls
+        whose name is still growing when the stream ends are emitted in the
+        finalize phase below. A truncated name must never appear in added/done.
+        """
+        if idx in tool_call_open:
+            return
+        flat_name = tool_calls[idx]["function"]["name"]
+        ns, _, n = flat_name.rpartition("__")
+        if not ns or not n:
+            ns, n = None, flat_name
+        fc_id = f"fc_{uuid.uuid4().hex}"
+        call_id = tool_calls[idx]["id"] or f"call_{uuid.uuid4().hex}"
+        tc_item: Json = {
+            "type": "function_call", "id": fc_id, "call_id": call_id,
+            "name": n, "arguments": "", "status": "in_progress",
+        }
+        if ns:
+            tc_item["namespace"] = ns
+        tool_call_items[idx] = tc_item
+        send_event({"type": "response.output_item.added",
+                    "output_index": (1 if reasoning_emitted else 0) + idx, "item": tc_item})
+        tool_call_open.add(idx)
 
     # Keepalive: send SSE comments every 15s while waiting for upstream first byte.
     # Prevents Codex from timing out when the model thinks for 30+ seconds before responding.
@@ -436,7 +505,7 @@ def handle_streaming_request(payload: Json, config: ProxyConfig, request_id: str
             response = urllib.request.urlopen(req, timeout=config.timeout_sec)
         except urllib.error.HTTPError as exc:
             body = exc.read().decode("utf-8", errors="replace")
-            trace("upstream.error", request_id=request_id, status=exc.code, body=body[:2000])
+            trace("upstream.error", request_id=request_id, status=exc.code, body=_mask_trace_body(body))
             if _retriable_http_status(exc.code) and retries < max_retries:
                 retries += 1
                 trace("upstream.retry", request_id=request_id, attempt=retries, status=exc.code)
@@ -450,8 +519,10 @@ def handle_streaming_request(payload: Json, config: ProxyConfig, request_id: str
                 send_error(f"upstream unavailable (HTTP {exc.code})")
             else:
                 send_error(f"upstream HTTP {exc.code}")
-            record_usage_event(model=model, status=502, duration_ms=int((time.time() - started) * 1000),
-                               stream_aborted=True, retries=retries)
+            # No upstream bytes were ever streamed, so this is not a mid-stream
+            # abort: meter the real final upstream status, not a synthetic 502.
+            record_usage_event(model=model, status=exc.code, duration_ms=int((time.time() - started) * 1000),
+                               retries=retries)
             return
         except (urllib.error.URLError, TimeoutError) as exc:
             trace("upstream.network_error", request_id=request_id, reason=str(getattr(exc, "reason", exc)))
@@ -462,8 +533,10 @@ def handle_streaming_request(payload: Json, config: ProxyConfig, request_id: str
                 continue
             keepalive_stop.set()
             send_error(f"upstream network error: {getattr(exc, 'reason', exc)}")
+            # Network failure: no upstream status exists (502) and nothing was
+            # streamed, so no streamAborted marker.
             record_usage_event(model=model, status=502, duration_ms=int((time.time() - started) * 1000),
-                               stream_aborted=True, retries=retries)
+                               retries=retries)
             return
 
     try:
@@ -495,6 +568,7 @@ def handle_streaming_request(payload: Json, config: ProxyConfig, request_id: str
                             "type": "reasoning", "id": reasoning_id, "summary": [], "status": "in_progress",
                         }})
                         reasoning_open = True
+                        reasoning_emitted = True
                     reasoning += r
                     send_event({"type": "response.reasoning_summary_text.delta",
                                 "item_id": reasoning_id, "output_index": 0, "summary_index": 0, "delta": r})
@@ -502,14 +576,14 @@ def handle_streaming_request(payload: Json, config: ProxyConfig, request_id: str
                 d = delta.get("content")
                 if isinstance(d, str) and d:
                     if not item_open:
-                        idx = 1 if reasoning_open else 0
+                        idx = 1 if reasoning_emitted else 0
                         send_event({"type": "response.output_item.added", "output_index": idx, "item": {
                             "type": "message", "id": message_id, "role": "assistant",
                             "status": "in_progress", "content": [],
                         }})
                         item_open = True
                     text += d
-                    send_event({"type": "response.output_text.delta", "item_id": message_id, "output_index": 1 if reasoning_open else 0, "delta": d})
+                    send_event({"type": "response.output_text.delta", "item_id": message_id, "output_index": 1 if reasoning_emitted else 0, "delta": d})
                 tcs = delta.get("tool_calls")
                 if isinstance(tcs, list) and tcs and reasoning_open:
                     # Close reasoning item before tool calls so UI shows tool calls, not "thinking".
@@ -528,29 +602,12 @@ def handle_streaming_request(payload: Json, config: ProxyConfig, request_id: str
                         name_delta = fn.get("name")
                         if name_delta:
                             tool_calls[idx]["function"]["name"] += name_delta
-                            # Emit output_item.added as soon as we have the full tool name.
-                            # DeepSeek sends the name in one chunk, so first non-empty name = complete.
-                            if idx not in tool_call_open and tool_calls[idx]["function"]["name"]:
-                                flat_name = tool_calls[idx]["function"]["name"]
-                                ns, _, n = flat_name.rpartition("__")
-                                if not ns or not n:
-                                    ns, n = None, flat_name
-                                fc_id = f"fc_{uuid.uuid4().hex}"
-                                call_id = tool_calls[idx]["id"] or f"call_{uuid.uuid4().hex}"
-                                tc_item: Json = {
-                                    "type": "function_call", "id": fc_id,
-                                    "call_id": call_id, "name": n,
-                                    "arguments": "", "status": "in_progress",
-                                }
-                                if ns:
-                                    tc_item["namespace"] = ns
-                                tool_call_items[idx] = tc_item
-                                tc_base = 1 if reasoning_open else 0
-                                send_event({"type": "response.output_item.added",
-                                            "output_index": tc_base + idx, "item": tc_item})
-                                tool_call_open.add(idx)
-                        if fn.get("arguments"):
-                            tool_calls[idx]["function"]["arguments"] += fn["arguments"]
+                        args_delta = fn.get("arguments")
+                        if args_delta:
+                            tool_calls[idx]["function"]["arguments"] += args_delta
+                            # Arguments only start after the final name chunk, so
+                            # the accumulated name is complete: emit added now.
+                            emit_tool_added(idx)
     except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError, OSError) as exc:
         # The upstream stream died after its 200 head was already committed to
         # the client. Surface an error and mark the turn as aborted so the
@@ -595,20 +652,30 @@ def handle_streaming_request(payload: Json, config: ProxyConfig, request_id: str
         send_event({"type": "response.output_item.done", "output_index": 0, "item": rs_done})
 
     # Emit output_item.done for tool calls that were opened during streaming,
-    # and added+done for any that weren't (e.g. name arrived in non-stream chunk).
-    tc_base = 1 if reasoning_open else 0
+    # and added+done for any that weren't (e.g. name only completed at stream
+    # end) — always with the complete name.
+    tc_base = 1 if reasoning_emitted else 0
     tc_count = 0
     for item in output:
         if item.get("type") != "function_call":
             continue
         idx = tc_base + tc_count
         if tc_count in tool_call_open:
-            # Already emitted added; update with final arguments and close.
+            # Already emitted added during streaming; close with the final
+            # name/arguments and keep the streamed item id.
             done_item = dict(tool_call_items[tc_count])
+            done_item["name"] = item["name"]
             done_item["arguments"] = item.get("arguments", "{}")
             done_item["status"] = "completed"
             send_event({"type": "response.output_item.done", "output_index": idx, "item": done_item})
+            # Completed must reuse the streamed ids so Codex reconciles items
+            # by id instead of creating ghost duplicates.
+            item["id"] = tool_call_items[tc_count]["id"]
+            item["call_id"] = tool_call_items[tc_count]["call_id"]
         else:
+            # Added was never emitted during streaming: emit added+done now
+            # with the complete name.
+            tool_call_items[tc_count] = item
             send_event({"type": "response.output_item.added", "output_index": idx, "item": item})
             send_event({"type": "response.output_item.done", "output_index": idx, "item": item})
         tc_count += 1
@@ -619,6 +686,13 @@ def handle_streaming_request(payload: Json, config: ProxyConfig, request_id: str
         msg_done = {"type": "message", "id": message_id, "role": "assistant", "status": "completed",
                      "content": [{"type": "output_text", "text": text, "annotations": []}]}
         send_event({"type": "response.output_item.done", "output_index": msg_idx, "item": msg_done})
+
+    # Reuse the ids already streamed in response.completed.
+    for out_item in output:
+        if out_item.get("type") == "reasoning":
+            out_item["id"] = reasoning_id
+        elif out_item.get("type") == "message":
+            out_item["id"] = message_id
 
     final: Json = {
         "id": response_id, "object": "response", "created_at": now_unix(),
@@ -756,7 +830,7 @@ def call_upstream_chat(chat_payload: Json, config: ProxyConfig, request_id: str,
                 return value, retries
         except urllib.error.HTTPError as exc:
             body = exc.read().decode("utf-8", errors="replace")
-            trace("upstream.error", request_id=request_id, status=exc.code, body=body[:2000])
+            trace("upstream.error", request_id=request_id, status=exc.code, body=_mask_trace_body(body))
             if _retriable_http_status(exc.code) and retries < max_retries:
                 retries += 1
                 trace("upstream.retry", request_id=request_id, attempt=retries, status=exc.code)
@@ -764,12 +838,12 @@ def call_upstream_chat(chat_payload: Json, config: ProxyConfig, request_id: str,
                 continue
             if exc.code == 429:
                 retry_after = exc.headers.get("retry-after", "5")
-                raise ProxyError(HTTPStatus.TOO_MANY_REQUESTS, f"rate limited (retry after {retry_after}s)") from exc
+                raise ProxyError(HTTPStatus.TOO_MANY_REQUESTS, f"rate limited (retry after {retry_after}s)", retries=retries) from exc
             if exc.code == 503:
-                raise ProxyError(HTTPStatus.SERVICE_UNAVAILABLE, "upstream unavailable") from exc
+                raise ProxyError(HTTPStatus.SERVICE_UNAVAILABLE, "upstream unavailable", retries=retries) from exc
             if exc.code == 504:
-                raise ProxyError(HTTPStatus.GATEWAY_TIMEOUT, "upstream timeout") from exc
-            raise ProxyError(HTTPStatus.BAD_GATEWAY, f"upstream HTTP {exc.code}") from exc
+                raise ProxyError(HTTPStatus.GATEWAY_TIMEOUT, "upstream timeout", retries=retries) from exc
+            raise ProxyError(HTTPStatus.BAD_GATEWAY, f"upstream HTTP {exc.code}", retries=retries) from exc
         except urllib.error.URLError as exc:
             trace("upstream.network_error", request_id=request_id, reason=str(getattr(exc, "reason", exc)))
             if retries < max_retries:
@@ -777,7 +851,7 @@ def call_upstream_chat(chat_payload: Json, config: ProxyConfig, request_id: str,
                 trace("upstream.retry", request_id=request_id, attempt=retries, reason=str(getattr(exc, "reason", exc)))
                 _retry_sleep(retries)
                 continue
-            raise ProxyError(HTTPStatus.BAD_GATEWAY, f"upstream network error: {getattr(exc, 'reason', exc)}") from exc
+            raise ProxyError(HTTPStatus.BAD_GATEWAY, f"upstream network error: {getattr(exc, 'reason', exc)}", retries=retries) from exc
         except TimeoutError:
             trace("upstream.timeout", request_id=request_id, timeout=timeout_sec or config.timeout_sec)
             if retries < max_retries:
@@ -785,7 +859,7 @@ def call_upstream_chat(chat_payload: Json, config: ProxyConfig, request_id: str,
                 trace("upstream.retry", request_id=request_id, attempt=retries, reason="timeout")
                 _retry_sleep(retries)
                 continue
-            raise ProxyError(HTTPStatus.GATEWAY_TIMEOUT, "upstream timeout") from None
+            raise ProxyError(HTTPStatus.GATEWAY_TIMEOUT, "upstream timeout", retries=retries) from None
 
 
 _api_key_cache: str | None = None
@@ -863,7 +937,28 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str] | None = None) -> None:
-    args = build_parser().parse_args(argv)
+    args_list = list(sys.argv[1:] if argv is None else argv)
+    # Operational subcommands must be reachable from the installed console
+    # script (entry point is app:main), not only via python -m. Dispatch them
+    # before any server startup.
+    if "--refresh-catalog" in args_list or os.environ.get("OPENCODE_GO_PROXY_REFRESH_CATALOG") == "1":
+        args_list = [a for a in args_list if a != "--refresh-catalog"]
+        from . import catalog
+
+        sys.exit(catalog.main_refresh(args_list))
+    if args_list and args_list[0] == "doctor":
+        from . import ops
+
+        sys.exit(ops.doctor(args_list[1:]))
+    if args_list and args_list[0] == "smoke-test":
+        from . import ops
+
+        sys.exit(ops.smoke_test())
+    if args_list and args_list[0] == "support-bundle":
+        from . import ops
+
+        sys.exit(ops.support_bundle(args_list[1:]))
+    args = build_parser().parse_args(args_list)
     try:
         from opencode_go_proxy import catalog as _catalog
 

--- a/src/opencode_go_proxy/catalog.py
+++ b/src/opencode_go_proxy/catalog.py
@@ -77,10 +77,11 @@ def _model_from_discovery(m: dict) -> dict:
             "slug": m.get("id", ""),
             "display_name": m.get("name", ""),
             "description": m.get("description", ""),
-            "context_window": context,
-            "max_context_window": context,
         }
     )
+    if isinstance(context, int) and context > 0:
+        record["context_window"] = context
+        record["max_context_window"] = context
     if isinstance(modalities, list) and modalities:
         record["input_modalities"] = modalities
     if isinstance(reasoning, dict):
@@ -193,11 +194,11 @@ IDENTITY_LINE = (
 
 def model_messages(shared_instructions: str, display_name: str, context_window: int) -> dict[str, Any]:
     """Build the model_messages dict Codex requires for a rendered model."""
-    instructions_template = shared_instructions.replace(
-        shared_instructions.splitlines()[0],
-        IDENTITY_LINE.format(display_name=display_name),
-        1,
-    )
+    identity = IDENTITY_LINE.format(display_name=display_name)
+    if not shared_instructions:
+        instructions_template = identity
+    else:
+        instructions_template = shared_instructions.replace(shared_instructions.splitlines()[0], identity, 1)
     return {
         "instructions_template": instructions_template,
         "supports_reasoning_summaries": True,

--- a/src/opencode_go_proxy/ops.py
+++ b/src/opencode_go_proxy/ops.py
@@ -1,8 +1,8 @@
 """Operational commands: doctor, smoke-test, support-bundle.
 
-Stdlib-only and single-provider like the rest of the proxy. Each command is
-read-mostly and never mutates user config. `doctor` returns non-zero exit when
-any check fails; `smoke-test` returns non-zero when the upstream probe fails;
+Stdlib-only and single-provider like the rest of the proxy. `doctor` is
+read-only: it inspects env/keychain, /health, the meter, logs, and config, and
+records nothing. `smoke-test` sends one real chat-completion to upstream;
 `support-bundle` writes a tarball that redacts secret values.
 """
 
@@ -12,6 +12,7 @@ import io
 import json
 import os
 import re
+import subprocess
 import sys
 import tarfile
 import time
@@ -20,7 +21,7 @@ import urllib.request
 from typing import Any
 
 from . import __version__
-from .meter import record_usage_event, usage_events_path
+from .meter import usage_events_path
 
 Json = dict[str, Any]
 
@@ -33,9 +34,12 @@ CHAT_BASE_URL = os.environ.get("CHAT_COMPLETIONS_BASE_URL", "https://opencode.ai
 _LOG_NAMES = ("opencode-go-proxy.log", "opencode-go-proxy.err")
 
 # Secret-looking keys redacted from the support bundle; everything else is
-# left verbatim so a config dump stays readable.
+# left verbatim so a config dump stays readable. The key name is any run of
+# word characters ending in a secret suffix (so OPENCODE_API_KEY and
+# env.api_key match, not just a bare api_key), bounded by a non-word char
+# before it, and the value may be single- or double-quoted TOML.
 _SECRET_KEY = re.compile(
-    r'(?i)\b(api[_-]?key|apikey|token|secret|password|authorization|bearer|access[_-]?key)\b\s*=\s*"[^"]*"'
+    r'(?i)(?<![\w])([A-Za-z0-9_]*?(?:api[_-]?key|apikey|token|secret|password|authorization|bearer|access[_-]?key))\s*=\s*(?:"[^"]*"|\'[^\']*\')'
 )
 
 
@@ -57,12 +61,53 @@ def _configured_key_env() -> str:
     return os.environ.get("OPENCODE_GO_PROXY_API_KEY_ENV", "OPENCODE_GO_API_KEY")
 
 
+# Keychain services that may hold the API key. Mirrors app.resolve_api_key's
+# order so doctor reports the same resolution the proxy actually uses: the
+# configured env var, then $OPENCODE_API_KEY, then the macOS keychain.
+_KEYCHAIN_SERVICES: tuple[str, ...] = ("opencode-go-api-key", "codex-router-opencode-go")
+
+
+def _keychain_services() -> list[str]:
+    services: list[str] = []
+    service_env = os.environ.get("CODEX_KEYCHAIN_SERVICE")
+    if service_env:
+        services.append(service_env)
+    services.extend(_KEYCHAIN_SERVICES)
+    return list(dict.fromkeys(services))
+
+
+def _resolve_api_key() -> tuple[str, str] | None:
+    """Resolve the API key the way the proxy does; return (value, source) or None.
+
+    Never prints the value; callers use it only for a presence check.
+    """
+    for env in (_configured_key_env(), "OPENCODE_API_KEY"):
+        if not env:
+            continue
+        value = os.environ.get(env)
+        if value:
+            return value, f"${env}"
+    for keychain_service in _keychain_services():
+        try:
+            completed = subprocess.run(
+                ["security", "find-generic-password", "-a", os.environ.get("USER", ""), "-s", keychain_service, "-w"],
+                check=False, capture_output=True, text=True, stdin=subprocess.DEVNULL, timeout=10,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            continue
+        if completed.returncode == 0:
+            first_line = completed.stdout.splitlines()[0].strip() if completed.stdout.splitlines() else ""
+            if first_line:
+                return first_line, f"keychain:{keychain_service}"
+    return None
+
+
 def check_api_key() -> Check:
-    """The proxy key is present in its configured env var (never printed)."""
-    value = os.environ.get(_configured_key_env())
-    if value:
-        return Check("api key", True, f"resolved from ${_configured_key_env()}")
-    return Check("api key", False, f"set ${_configured_key_env()} or run `opencode-go-proxy` with the key present")
+    """The proxy key is present in env or the macOS keychain (never printed)."""
+    resolved = _resolve_api_key()
+    if resolved is not None:
+        return Check("api key", True, f"resolved from {resolved[1]}")
+    return Check("api key", False, f"set ${_configured_key_env()}, $OPENCODE_API_KEY, or keychain:{_KEYCHAIN_SERVICES[0]}")
 
 
 def check_service(url: str = HEALTH_URL) -> Check:
@@ -75,12 +120,17 @@ def check_service(url: str = HEALTH_URL) -> Check:
 
 
 def check_meter() -> Check:
-    """The usage meter is writable at its configured location."""
-    record_usage_event(model="doctor", status=0, duration_ms=0)
+    """The usage meter is writable at its configured location; probe never records."""
     path = usage_events_path()
-    if os.path.exists(path):
-        return Check("meter", True, path)
-    return Check("meter", False, "cannot write usage-events.jsonl")
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        # Probe writability without recording: an append-mode open creates the
+        # file if missing but adds no content, so the honest meter stays clean.
+        with open(path, "a", encoding="utf-8"):
+            pass
+    except OSError:
+        return Check("meter", False, "cannot write usage-events.jsonl")
+    return Check("meter", True, path)
 
 
 def check_logs() -> Check:

--- a/src/opencode_go_proxy/protocol.py
+++ b/src/opencode_go_proxy/protocol.py
@@ -8,16 +8,71 @@ from typing import Any
 
 Json = dict[str, Any]
 
+
+def _as_int(value: Any) -> int:
+    """Coerce an upstream token count to int, tolerating malformed values.
+
+    Upstream usage may carry string or missing token fields; a malformed value
+    must never crash a request that was already billed upstream.
+    """
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return 0
+    return 0
+
+
 SESSION_SPAWN_TOOLS = {"create_thread", "send_message_to_thread"}
 
 
+def _translate_tool_choice(tool_choice: Any) -> Any:
+    """Map a Responses tool_choice to the Chat Completions shape.
+
+    Responses uses {"type": "function", "name": X} and {"type": "auto|required|none"};
+    Chat Completions needs {"type": "function", "function": {"name": X}} and the
+    bare strings "auto" / "required" / "none". Anything unrecognized is dropped
+    so the upstream applies its own default rather than failing on a bad shape.
+    """
+    if isinstance(tool_choice, str):
+        return tool_choice
+    if isinstance(tool_choice, dict):
+        t = tool_choice.get("type")
+        if t == "function":
+            name = tool_choice.get("name")
+            if isinstance(name, str) and name:
+                return {"type": "function", "function": {"name": name}}
+            return None
+        if t in ("auto", "required", "none"):
+            return t
+    return None
+
+
 def _session_spawn_name(item: Json) -> str | None:
-    """Return the bare tool name of a function_call item, if it is a session-spawn call."""
+    """Return the bare tool name of a function_call item, if it is a session-spawn call.
+
+    Only genuine codex_app thread-spawn tools match, so unrelated MCP tools
+    (e.g. mcp__slack__create_thread) are never rewritten. Accepted forms:
+    - flat: name is "codex_app__create_thread" / "codex_app__send_message_to_thread"
+    - namespaced: namespace is absent or "codex_app" with a bare spawn-tool name
+    """
     name = item.get("name")
-    if isinstance(name, str) and "__" in name:
-        # Flat namespace form: codex_app__create_thread.
-        name = name.rsplit("__", 1)[1]
-    if not isinstance(name, str) or name not in SESSION_SPAWN_TOOLS:
+    if not isinstance(name, str):
+        return None
+    if "__" in name:
+        namespace, _, bare = name.partition("__")
+        if namespace != "codex_app" or bare not in SESSION_SPAWN_TOOLS:
+            return None
+        return bare
+    if item.get("namespace") not in (None, "codex_app"):
+        return None
+    if name not in SESSION_SPAWN_TOOLS:
         return None
     return name
 
@@ -52,6 +107,9 @@ def inject_session_model(payload: Json, session_model: str) -> Json:
             continue
         model = parsed.get("model")
         if model is not None and model != "":
+            continue
+        if model is None and "model" in parsed:
+            # {"model": null} is explicitly present — leave it as-is.
             continue
         parsed["model"] = session_model
         item["arguments"] = json.dumps(parsed, sort_keys=True)
@@ -477,7 +535,9 @@ def responses_payload_to_chat_payload(payload: Json) -> tuple[Json, str, Json]:
     if tools is not None:
         chat_payload["tools"] = tools
         if payload.get("tool_choice") is not None:
-            chat_payload["tool_choice"] = payload["tool_choice"]
+            choice = _translate_tool_choice(payload["tool_choice"])
+            if choice is not None:
+                chat_payload["tool_choice"] = choice
 
     if payload.get("temperature") is not None:
         chat_payload["temperature"] = payload["temperature"]
@@ -609,7 +669,7 @@ def cache_stats_from_usage(usage: Any) -> Json:
     hit = hit_raw if isinstance(hit_raw, int) else (cached_raw if isinstance(cached_raw, int) else 0)
     if not isinstance(hit, int):
         hit = 0
-    miss = miss_raw if isinstance(miss_raw, int) else max(0, int(input_tokens or 0) - hit)
+    miss = miss_raw if isinstance(miss_raw, int) else max(0, _as_int(input_tokens) - hit)
     if hit == 0 and miss == 0:
         return {"hit": 0, "miss": 0, "ratio": None}
     total = hit + miss
@@ -619,12 +679,12 @@ def cache_stats_from_usage(usage: Any) -> Json:
 def normalize_usage(usage: Any) -> Json | None:
     if not isinstance(usage, dict):
         return None
-    input_tokens = usage.get("prompt_tokens", usage.get("input_tokens", 0))
-    output_tokens = usage.get("completion_tokens", usage.get("output_tokens", 0))
+    input_tokens = _as_int(usage.get("prompt_tokens", usage.get("input_tokens", 0)))
+    output_tokens = _as_int(usage.get("completion_tokens", usage.get("output_tokens", 0)))
     normalized: Json = {
         "input_tokens": input_tokens,
         "output_tokens": output_tokens,
-        "total_tokens": usage.get("total_tokens", input_tokens + output_tokens),
+        "total_tokens": _as_int(usage.get("total_tokens", input_tokens + output_tokens)),
     }
     # Surf the upstream's own prefix-cache accounting back to Codex in the
     # standard Responses shape so the app's token display shows cache hits,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -12,6 +12,7 @@ import zstandard
 from opencode_go_proxy.app import (
     ProxyConfig,
     ProxyError,
+    _caption_timeout_sec,
     _mask_trace_body,
     decode_request_body,
     resolve_api_key,
@@ -249,6 +250,23 @@ class MaskTraceBodyTests(unittest.TestCase):
     def test_truncates_to_limit(self) -> None:
         masked = _mask_trace_body("x" * 5000, limit=100)
         self.assertEqual(len(masked), 100)
+
+
+class CaptionTimeoutTests(unittest.TestCase):
+    def test_defaults_to_60_seconds(self) -> None:
+        self.assertEqual(_caption_timeout_sec(), 60.0)
+
+    def test_env_override_applies(self) -> None:
+        with unittest.mock.patch.dict("os.environ", {"OPENCODE_GO_PROXY_CAPTION_TIMEOUT_SEC": "90"}):
+            self.assertEqual(_caption_timeout_sec(), 90.0)
+
+    def test_malformed_env_falls_back_to_default(self) -> None:
+        with unittest.mock.patch.dict("os.environ", {"OPENCODE_GO_PROXY_CAPTION_TIMEOUT_SEC": "not-a-number"}):
+            self.assertEqual(_caption_timeout_sec(), 60.0)
+
+    def test_zero_env_is_clamped_to_one_second(self) -> None:
+        with unittest.mock.patch.dict("os.environ", {"OPENCODE_GO_PROXY_CAPTION_TIMEOUT_SEC": "0"}):
+            self.assertEqual(_caption_timeout_sec(), 1.0)
 
 
 if __name__ == "__main__":

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,4 +1,6 @@
 import gzip
+import io
+import json
 import os
 import subprocess
 import unittest
@@ -10,6 +12,7 @@ import zstandard
 from opencode_go_proxy.app import (
     ProxyConfig,
     ProxyError,
+    _mask_trace_body,
     decode_request_body,
     resolve_api_key,
 )
@@ -118,6 +121,134 @@ class RequestBodyDecodeTests(unittest.TestCase):
         with self.assertRaises(ProxyError) as ctx:
             decode_request_body(compressed, "zstd", 1024)
         self.assertEqual(ctx.exception.status, HTTPStatus.REQUEST_ENTITY_TOO_LARGE)
+
+    def test_gzip_decompression_is_bounded(self) -> None:
+        # A small gzip body that decompresses past the cap must 413 instead of
+        # ballooning into a huge allocation (gzip.decompress has no output cap).
+        raw = b"x" * (8 * 1024 * 1024)
+        compressed = gzip.compress(raw)
+        with self.assertRaises(ProxyError) as ctx:
+            decode_request_body(compressed, "gzip", 1024)
+        self.assertEqual(ctx.exception.status, HTTPStatus.REQUEST_ENTITY_TOO_LARGE)
+
+
+class _UpstreamStream:
+    """Minimal stand-in for an upstream SSE response: iterable + context manager."""
+
+    def __init__(self, lines: list[bytes]) -> None:
+        self._lines = list(lines)
+        self.status = 200
+        self.headers = {}
+
+    def __iter__(self):
+        return iter(self._lines)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args: object) -> bool:
+        return False
+
+
+def _run_stream(lines: list[bytes]) -> list[dict]:
+    """Drive handle_streaming_request against `lines` and parse its SSE events."""
+    import opencode_go_proxy.app as app_mod
+    from opencode_go_proxy.app import handle_streaming_request
+
+    app_mod._api_key_cache = None
+    cfg = make_config()
+    payload = {"model": "deepseek-v4-flash", "input": "hi", "stream": True}
+    wfile = io.BytesIO()
+    with mock.patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "test-key"}), \
+         mock.patch("urllib.request.urlopen", return_value=_UpstreamStream(lines)):
+        handle_streaming_request(payload, cfg, "req-stream", wfile)
+    events: list[dict] = []
+    for block in wfile.getvalue().decode("utf-8").split("\n\n"):
+        block = block.strip()
+        if not block.startswith("data: "):
+            continue
+        data = block[len("data: "):]
+        if data == "[DONE]":
+            continue
+        events.append(json.loads(data))
+    return events
+
+
+class StreamingSseTests(unittest.TestCase):
+    def test_reasoning_then_split_tool_call_indices_names_ids(self) -> None:
+        # Reasoning followed by a tool call whose name arrives in chunks
+        # ('read_' + 'file'). The function_call must stream at output_index 1
+        # (not collide with the closed reasoning item at 0), carry the full
+        # name on added and done, and keep the same id in response.completed.
+        lines = [
+            b'data: {"id":"1","choices":[{"index":0,"delta":{"reasoning_content":"Let me think"}}]}\n',
+            b'data: {"id":"1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"read_"}}]}}]}\n',
+            b'data: {"id":"1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"name":"file"}}]}}]}\n',
+            b'data: {"id":"1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\\"path\\":\\"README.md\\"}"}}]}}]}\n',
+            b'data: {"id":"1","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":5,"completion_tokens":2,"total_tokens":7}}\n',
+            b'data: [DONE]\n',
+        ]
+        events = _run_stream(lines)
+        added = [e for e in events if e["type"] == "response.output_item.added"]
+        done = [e for e in events if e["type"] == "response.output_item.done"]
+        reasoning_added = next(e for e in added if e["item"]["type"] == "reasoning")
+        fc_added = next(e for e in added if e["item"]["type"] == "function_call")
+        fc_done = next(e for e in done if e["item"]["type"] == "function_call")
+        # Reasoning keeps output_index 0; the tool call takes 1, never 0.
+        self.assertEqual(reasoning_added["output_index"], 0)
+        self.assertEqual(fc_added["output_index"], 1)
+        # The split tool name must be complete on both added and done.
+        self.assertEqual(fc_added["item"]["name"], "read_file")
+        self.assertEqual(fc_done["item"]["name"], "read_file")
+        # response.completed reuses the streamed item ids (no ghost items).
+        completed = next(e for e in events if e["type"] == "response.completed")["response"]
+        fc_out = next(o for o in completed["output"] if o["type"] == "function_call")
+        reasoning_out = next(o for o in completed["output"] if o["type"] == "reasoning")
+        self.assertEqual(fc_out["id"], fc_added["item"]["id"])
+        self.assertEqual(reasoning_out["id"], reasoning_added["item"]["id"])
+
+    def test_reasoning_then_text_streams_at_index_1(self) -> None:
+        # Text that follows a reasoning item must stream at output_index 1,
+        # not 0 (same collision class as the tool-call path).
+        lines = [
+            b'data: {"id":"1","choices":[{"index":0,"delta":{"reasoning_content":"think"}}]}\n',
+            b'data: {"id":"1","choices":[{"index":0,"delta":{"content":"answer"}}]}\n',
+            b'data: {"id":"1","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":2,"total_tokens":7}}\n',
+            b'data: [DONE]\n',
+        ]
+        events = _run_stream(lines)
+        added = [e for e in events if e["type"] == "response.output_item.added"]
+        msg_added = next(e for e in added if e["item"]["type"] == "message")
+        self.assertEqual(msg_added["output_index"], 1)
+        deltas = [e for e in events if e["type"] == "response.output_text.delta"]
+        self.assertTrue(deltas)
+        self.assertEqual(deltas[0]["output_index"], 1)
+        self.assertEqual(deltas[0]["item_id"], msg_added["item"]["id"])
+        completed = next(e for e in events if e["type"] == "response.completed")["response"]
+        msg_out = next(o for o in completed["output"] if o["type"] == "message")
+        self.assertEqual(msg_out["id"], msg_added["item"]["id"])
+
+
+class MaskTraceBodyTests(unittest.TestCase):
+    def test_masks_sk_tokens_and_authorization_header(self) -> None:
+        masked = _mask_trace_body(
+            '{"error":"invalid","Authorization": "Bearer sk-abc123DEF456ghi789jkl"} sk-abc123DEF456ghi789jkl'
+        )
+        self.assertNotIn("sk-abc123DEF456ghi789jkl", masked)
+        self.assertNotIn("Bearer", masked)
+
+    def test_masks_block_form_authorization_header(self) -> None:
+        masked = _mask_trace_body("Authorization: Bearer sk-abc123DEF456ghi789jkl")
+        self.assertNotIn("sk-abc123DEF456ghi789jkl", masked)
+        self.assertNotIn("Bearer", masked)
+
+    def test_leaves_plain_body_untouched(self) -> None:
+        body = "upstream is having a bad day"
+        self.assertEqual(_mask_trace_body(body), body)
+
+    def test_truncates_to_limit(self) -> None:
+        masked = _mask_trace_body("x" * 5000, limit=100)
+        self.assertEqual(len(masked), 100)
 
 
 if __name__ == "__main__":

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -8,9 +8,12 @@ from unittest import mock
 
 from opencode_go_proxy.catalog import (
     CatalogDiscoveryError,
+    _model_from_discovery,
     discover_models,
     load_known_slugs,
     merge_models,
+    model_messages,
+    render_full_catalog,
 )
 
 
@@ -106,6 +109,70 @@ class LoadKnownSlugsTests(unittest.TestCase):
             slugs = load_known_slugs(catalog_path=str(missing))
 
         self.assertEqual(slugs, set())
+
+
+def minimal_compact(shared_instructions: str, model: dict) -> dict:
+    return {
+        "fetched_at": "2026-08-10T12:00:00.000000Z",
+        "etag": 'W/"opencode-go-models-test"',
+        "shared_instructions": shared_instructions,
+        "client_version": "0.147.0",
+        "models": [model],
+    }
+
+
+def minimal_model(**overrides: object) -> dict:
+    record = {
+        "slug": "cold-start-model",
+        "display_name": "Cold Start Model",
+        "description": "Rendered on first discovery.",
+        "default_reasoning_level": "medium",
+        "supported_reasoning_levels": [{"effort": "low", "description": "Lighter"}],
+        "context_window": 1000000,
+        "max_context_window": 1000000,
+    }
+    record.update(overrides)
+    return record
+
+
+class ColdStartRenderTests(unittest.TestCase):
+    def test_render_with_empty_shared_instructions_does_not_crash(self) -> None:
+        compact = minimal_compact("", minimal_model())
+
+        rendered = render_full_catalog(compact)
+
+        model = rendered["models"][0]
+        self.assertEqual(model["base_instructions"], "")
+        template = model["model_messages"]["instructions_template"]
+        self.assertIn("You are Codex, a coding agent based on Cold Start Model.", template)
+
+    def test_model_messages_with_empty_shared_instructions_uses_identity_line(self) -> None:
+        messages = model_messages("", "Cold Start Model", 1000000)
+
+        self.assertEqual(
+            messages["instructions_template"],
+            "You are Codex, a coding agent based on Cold Start Model. You and the user "
+            "share one workspace, and your job is to collaborate with them until their "
+            "goal is genuinely handled.",
+        )
+        self.assertEqual(messages["auto_compact_token_limit"], 900000)
+
+    def test_discovery_without_limit_context_keeps_default(self) -> None:
+        record = _model_from_discovery({"id": "no-context-model", "name": "No Context"})
+
+        self.assertEqual(record["context_window"], 1000000)
+        self.assertEqual(record["max_context_window"], 1000000)
+
+    def test_render_with_default_context_window_does_not_crash(self) -> None:
+        discovered = _model_from_discovery({"id": "no-context-model", "name": "No Context"})
+        compact = minimal_compact("Line one\n", discovered)
+
+        rendered = render_full_catalog(compact)
+
+        self.assertEqual(
+            rendered["models"][0]["model_messages"]["auto_compact_token_limit"],
+            round(1000000 * 0.9),
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_meter.py
+++ b/tests/test_meter.py
@@ -89,6 +89,10 @@ class MeterRecordTests(unittest.TestCase):
             record_usage_event(model="m", status=200, duration_ms=1)  # must not raise
 
     def test_default_state_dir_is_codex_dir(self) -> None:
+<<<<<<< HEAD
+=======
+        # True default (env cleared, not the autouse tmp override).
+>>>>>>> 913b72c (test: isolate all tests from the real state dir (conftest autouse fixture))
         with mock.patch.dict(os.environ, {}, clear=True):
             self.assertIn(".codex", state_dir())
 

--- a/tests/test_meter.py
+++ b/tests/test_meter.py
@@ -89,10 +89,7 @@ class MeterRecordTests(unittest.TestCase):
             record_usage_event(model="m", status=200, duration_ms=1)  # must not raise
 
     def test_default_state_dir_is_codex_dir(self) -> None:
-<<<<<<< HEAD
-=======
         # True default (env cleared, not the autouse tmp override).
->>>>>>> 913b72c (test: isolate all tests from the real state dir (conftest autouse fixture))
         with mock.patch.dict(os.environ, {}, clear=True):
             self.assertIn(".codex", state_dir())
 

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -31,13 +31,33 @@ def _http_error(code: int, body: str = ""):
 
 class TestApiKey:
     def test_missing(self) -> None:
-        with mock.patch.dict(os.environ, {}, clear=False):
+        with mock.patch.dict(os.environ, {}, clear=False), \
+             mock.patch("opencode_go_proxy.ops.subprocess.run", side_effect=FileNotFoundError("no security")):
             os.environ.pop("OPENCODE_GO_API_KEY", None)
+            os.environ.pop("OPENCODE_API_KEY", None)
             c = ops.check_api_key()
         assert not c.ok
 
     def test_present(self) -> None:
         with mock.patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "sk-abc123"}):
+            assert ops.check_api_key().ok
+
+    def test_env_takes_precedence_over_keychain(self) -> None:
+        with mock.patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "sk-env"}), \
+             mock.patch("opencode_go_proxy.ops.subprocess.run") as run:
+            assert ops.check_api_key().ok
+        run.assert_not_called()
+
+    def test_generic_env_fallback(self) -> None:
+        with mock.patch.dict(os.environ, {"OPENCODE_API_KEY": "sk-generic"}, clear=True), \
+             mock.patch("opencode_go_proxy.ops.subprocess.run") as run:
+            assert ops.check_api_key().ok
+        run.assert_not_called()
+
+    def test_keychain_fallback(self) -> None:
+        with mock.patch.dict(os.environ, {}, clear=True), \
+             mock.patch("opencode_go_proxy.ops.subprocess.run",
+                        return_value=mock.Mock(returncode=0, stdout="sk-keychain\n")):
             assert ops.check_api_key().ok
 
 
@@ -60,6 +80,17 @@ class TestMeter:
             c = ops.check_meter()
         assert c.ok
         assert os.path.exists(os.path.join(str(tmp_path), "usage-events.jsonl"))
+
+    def test_read_only_does_not_record(self, tmp_path) -> None:
+        state = tmp_path / "state"
+        state.mkdir()
+        p = state / "usage-events.jsonl"
+        p.write_text('{"model":"deepseek-v4-flash","status":0}\n')
+        before = p.read_text()
+        with mock.patch.dict(os.environ, {"OPENCODE_GO_PROXY_STATE_DIR": str(state)}):
+            c = ops.check_meter()
+        assert c.ok
+        assert p.read_text() == before
 
 
 class TestLogs:
@@ -121,21 +152,32 @@ class TestSmoke:
             assert ops.smoke_test() == 1
 
     def test_missing_key(self) -> None:
-        with mock.patch.dict(os.environ, {}, clear=False):
+        with mock.patch.dict(os.environ, {}, clear=False), \
+             mock.patch("opencode_go_proxy.ops.subprocess.run", side_effect=FileNotFoundError("no security")):
             os.environ.pop("OPENCODE_GO_API_KEY", None)
+            os.environ.pop("OPENCODE_API_KEY", None)
             assert ops.smoke_test() == 1
 
 
 class TestMask:
     def test_redacts_secrets(self) -> None:
         assert ops._mask_secret_values('api_key = "sk-live"') == "api_key= ***redacted***"
+        assert ops._mask_secret_values("api_key = 'sk-single'") == "api_key= ***redacted***"
+        assert ops._mask_secret_values('OPENCODE_API_KEY = "sk-upper"') == "OPENCODE_API_KEY= ***redacted***"
+        assert ops._mask_secret_values('env = { OPENCODE_API_KEY = "sk-inline" }') == "env = { OPENCODE_API_KEY= ***redacted*** }"
         assert ops._mask_secret_values('model = "deepseek-v4-flash"') == 'model = "deepseek-v4-flash"'
 
 
 class TestSupportBundle:
     def test_bundle_contains_files_and_redacts(self, tmp_path) -> None:
         cfg = tmp_path / "config.toml"
-        cfg.write_text('openai_base_url = "http://127.0.0.1:8787/v1"\napi_key = "sk-secret-value"\n')
+        cfg.write_text(
+            'openai_base_url = "http://127.0.0.1:8787/v1"\n'
+            'api_key = "sk-secret-value"\n'
+            "api_key = 'sk-single-quoted'\n"
+            'OPENCODE_API_KEY = "sk-upper-style"\n'
+            'env = { OPENCODE_API_KEY = "sk-inline-env" }\n'
+        )
         log_dir = tmp_path / "logs"
         log_dir.mkdir()
         (log_dir / "opencode-go-proxy.err").write_text("2026-08-10 server.start\n")
@@ -150,7 +192,8 @@ class TestSupportBundle:
                 names.append(member.name)
                 if member.name == "opencode-go/config.toml":
                     text = tf.extractfile(member).read().decode()
-                    assert "sk-secret-value" not in text
+                    for secret in ("sk-secret-value", "sk-single-quoted", "sk-upper-style", "sk-inline-env"):
+                        assert secret not in text
                     assert "***redacted***" in text
         assert "opencode-go/version.json" in names
         assert "opencode-go/opencode-go-proxy.err" in names

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -362,6 +362,39 @@ class CacheAccountingTests(unittest.TestCase):
         normalized = normalize_usage({"prompt_tokens": 3, "completion_tokens": 2, "total_tokens": 5})
         self.assertEqual(normalized, {"input_tokens": 3, "output_tokens": 2, "total_tokens": 5})
 
+    def test_normalize_usage_tolerates_malformed_token_values(self) -> None:
+        # Non-numeric upstream token fields must never crash a billed request.
+        normalized = normalize_usage({
+            "prompt_tokens": "abc",
+            "completion_tokens": None,
+            "total_tokens": "nope",
+            "prompt_cache_hit_tokens": 0,
+            "prompt_cache_miss_tokens": 0,
+        })
+        self.assertEqual(normalized["input_tokens"], 0)
+        self.assertEqual(normalized["output_tokens"], 0)
+        self.assertEqual(normalized["total_tokens"], 0)
+
+    def test_tool_choice_function_shape_translated_to_chat(self) -> None:
+        chat_payload, _, _ = responses_payload_to_chat_payload({
+            "model": "opencode-go/deepseek-v4-flash",
+            "input": "hi",
+            "tools": [{"type": "function", "name": "read_file"}],
+            "tool_choice": {"type": "function", "name": "read_file"},
+        })
+        self.assertEqual(
+            chat_payload["tool_choice"], {"type": "function", "function": {"name": "read_file"}}
+        )
+
+    def test_tool_choice_auto_translated_to_string(self) -> None:
+        chat_payload, _, _ = responses_payload_to_chat_payload({
+            "model": "opencode-go/deepseek-v4-flash",
+            "input": "hi",
+            "tools": [{"type": "function", "name": "read_file"}],
+            "tool_choice": {"type": "auto"},
+        })
+        self.assertEqual(chat_payload["tool_choice"], "auto")
+
     def test_chat_completion_response_carries_cache_usage_through(self) -> None:
         response = chat_completion_to_response(
             {

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -1,5 +1,6 @@
 """Session-model inheritance for spawned threads (create_thread / send_message_to_thread)."""
 
+import copy
 import json
 import unittest
 
@@ -76,17 +77,44 @@ class SessionModelInjectionTests(unittest.TestCase):
         payload = payload_with(
             {"type": "function_call", "call_id": "call_1", "name": "exec_command", "arguments": "{}"}
         )
+        expected = copy.deepcopy(payload)
         result = inject_session_model(payload, SESSION_MODEL)
-        self.assertEqual(result, payload)
+        self.assertEqual(result, expected)
+        self.assertEqual(result["input"][0]["arguments"], "{}")
+
+    def test_mcp_namespaced_thread_tool_untouched(self) -> None:
+        payload = payload_with(
+            thread_call(name="mcp__slack__create_thread", arguments='{"channel":"general"}')
+        )
+        expected = copy.deepcopy(payload)
+        result = inject_session_model(payload, SESSION_MODEL)
+        self.assertEqual(result, expected)
+        self.assertEqual(result["input"][0]["arguments"], '{"channel":"general"}')
+
+    def test_bare_name_foreign_namespace_untouched(self) -> None:
+        payload = payload_with(thread_call(namespace="mcp_other", arguments="{}"))
+        expected = copy.deepcopy(payload)
+        result = inject_session_model(payload, SESSION_MODEL)
+        self.assertEqual(result, expected)
+        self.assertEqual(result["input"][0]["arguments"], "{}")
+
+    def test_null_model_is_present_and_untouched(self) -> None:
+        payload = payload_with(thread_call(arguments='{"model":null}'))
+        expected = copy.deepcopy(payload)
+        result = inject_session_model(payload, SESSION_MODEL)
+        self.assertEqual(result, expected)
+        self.assertEqual(result["input"][0]["arguments"], '{"model":null}')
 
     def test_malformed_arguments_untouched(self) -> None:
         payload = payload_with(
             thread_call(arguments="not-json{"),
             thread_call(arguments='{"model":null,"x":1}'),
         )
+        expected = copy.deepcopy(payload)
         result = inject_session_model(payload, SESSION_MODEL)
-        self.assertEqual(result, payload)
+        self.assertEqual(result, expected)
         self.assertEqual(result["input"][0]["arguments"], "not-json{")
+        self.assertEqual(result["input"][1]["arguments"], '{"model":null,"x":1}')
 
     def test_end_to_end_chat_payload_model_in_tool_call_args(self) -> None:
         payload = payload_with(

--- a/tests/test_reliability.py
+++ b/tests/test_reliability.py
@@ -179,9 +179,8 @@ class TestMeterThroughHandler:
         urlopen = mock.Mock(side_effect=http_error(429))
         with mock.patch.dict(os.environ, {"OPENCODE_GO_PROXY_MAX_RETRIES": "1"}), \
              mock.patch("urllib.request.urlopen", urlopen), \
-             mock.patch("opencode_go_proxy.app.time.sleep"):
-            with pytest.raises(ProxyError):
-                handle_responses_request(payload, cfg, "req9")
+             mock.patch("opencode_go_proxy.app.time.sleep"), pytest.raises(ProxyError):
+            handle_responses_request(payload, cfg, "req9")
         events = self._events()
         assert len(events) == 1
         e = events[0]

--- a/tests/test_reliability.py
+++ b/tests/test_reliability.py
@@ -16,10 +16,7 @@ from opencode_go_proxy.app import (
     ProxyError,
     call_upstream_chat,
     handle_responses_request,
-<<<<<<< HEAD
-=======
     handle_streaming_request,
->>>>>>> 023aafd (fix: apply 0.2.0 review findings (12-agent review pass))
 )
 from opencode_go_proxy.meter import usage_events_path
 

--- a/tests/test_reliability.py
+++ b/tests/test_reliability.py
@@ -16,6 +16,10 @@ from opencode_go_proxy.app import (
     ProxyError,
     call_upstream_chat,
     handle_responses_request,
+<<<<<<< HEAD
+=======
+    handle_streaming_request,
+>>>>>>> 023aafd (fix: apply 0.2.0 review findings (12-agent review pass))
 )
 from opencode_go_proxy.meter import usage_events_path
 
@@ -147,3 +151,42 @@ class TestMeterThroughHandler:
         assert e["input_tokens"] == 3
         assert e["total_tokens"] == 4
         assert "streamAborted" not in e
+
+    def _events(self) -> list[dict]:
+        with open(usage_events_path(), encoding="utf-8") as f:
+            return [json.loads(line) for line in f if line.strip()]
+
+    def test_streaming_429_exhausted_records_429_not_aborted(self, env) -> None:
+        # A connect-phase 429 exhaustion must meter the real upstream status,
+        # not a synthetic 502 + streamAborted (nothing was ever streamed).
+        cfg = make_config()
+        payload = {"model": "deepseek-v4-flash", "input": "hi", "stream": True}
+        urlopen = mock.Mock(side_effect=http_error(429, retry_after="5"))
+        with mock.patch.dict(os.environ, {"OPENCODE_GO_PROXY_MAX_RETRIES": "1"}), \
+             mock.patch("urllib.request.urlopen", urlopen), \
+             mock.patch("opencode_go_proxy.app.time.sleep"):
+            handle_streaming_request(payload, cfg, "req8", io.BytesIO())
+        assert urlopen.call_count == 2  # initial + 1 retry
+        events = self._events()
+        assert len(events) == 1
+        e = events[0]
+        assert e["status"] == 429
+        assert e["retries"] == 1
+        assert "streamAborted" not in e
+
+    def test_failed_turn_after_retry_records_retries(self, env) -> None:
+        # A non-streaming turn that exhausts retries must still report how many
+        # retries it burned (regression: ProxyError branch omitted retries).
+        cfg = make_config()
+        payload = {"model": "deepseek-v4-flash", "input": "hi", "stream": False}
+        urlopen = mock.Mock(side_effect=http_error(429))
+        with mock.patch.dict(os.environ, {"OPENCODE_GO_PROXY_MAX_RETRIES": "1"}), \
+             mock.patch("urllib.request.urlopen", urlopen), \
+             mock.patch("opencode_go_proxy.app.time.sleep"):
+            with pytest.raises(ProxyError):
+                handle_responses_request(payload, cfg, "req9")
+        events = self._events()
+        assert len(events) == 1
+        e = events[0]
+        assert e["status"] == 429
+        assert e["retries"] == 1

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.11"
 
 [options]
-exclude-newer = "2026-08-09T12:55:32.595Z"
+exclude-newer = "2026-08-09T14:42:31.463817Z"
 exclude-newer-span = "P1D"
 
 [[package]]
@@ -26,7 +26,7 @@ wheels = [
 
 [[package]]
 name = "opencode-go-proxy"
-version = "0.1.2"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "zstandard" },


### PR DESCRIPTION
Stack PR 6 of 6: proxy/skills -> proxy/menu. This is the cumulative top of the stack: 0.2.0 version bump, changelog, skills pack, and all review fixes folded on top of the feature branches.

- release: bump version to 0.2.0; sync hardcoded __version__
- skills: add opencode-go-proxy skill pack
- fix: apply 0.2.0 review findings (12-agent review pass)
- feat: MiMo caption timeout configurable (default 60s, OPENCODE_GO_PROXY_CAPTION_TIMEOUT_SEC)
- fix: start SSE keepalive BEFORE image captioning so a slow caption never leaves a silent stream
- test: isolate all tests from the real state dir (conftest autouse fixture)

Base: proxy/menu.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release `opencode-go-proxy` 0.2.0 with a new skill pack, safer request decoding, smarter streaming, and improved ops tooling. Adds `zstandard` as the single runtime dependency, removes silent streams, protects secrets in logs, and makes metering and retries more accurate.

- New Features
  - Add agent skill `skills/opencode-go-proxy`.
  - Decompress `Content-Encoding: zstd` and `gzip` with bounded output; 400 on unsupported encodings.
  - Configurable MiMo caption timeout via `OPENCODE_GO_PROXY_CAPTION_TIMEOUT_SEC` (default 60s).
  - Start SSE keepalive before image captioning to avoid silent streams.
  - Ops CLI dispatched from the console script: `doctor` checks env, keychain, meter (read-only); `smoke-test`; `support-bundle` with stronger redaction.
  - Return `426 Upgrade Required` for WebSocket upgrades so the app falls back to HTTP streaming.

- Bug Fixes
  - Streaming: fix `output_index` after reasoning; reuse streamed item ids in `response.completed`; never emit truncated tool names.
  - Metering: connect-phase streaming failures record the real upstream status; non-streaming failures now record retries.
  - Relay: only inject session model for `codex_app` `create_thread` / `send_message_to_thread`; keep `{"model": null}`; ignore foreign MCP tools.
  - Catalog: no crash on empty shared instructions or missing context; default context window applied.
  - Security: mask API keys and Authorization values echoed by upstream in trace logs (and support bundles).
  - Menu bar: close file descriptors on log open failure.
  - Protocol: translate `tool_choice` to Chat Completions shape; tolerate malformed usage token fields.
  - Tests: isolate state dir and catalog for hermetic CI; assert `/v1/models` response shape instead of machine-specific ids.

<sup>Written for commit 3c347ed418bbd65a00a1c1975e8d6a171111e80e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kartikkabadi/opencode-go-proxy/pull/8?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

