### PR TITLE
OpenCode Zen support, native compaction, production hardening (0.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## [0.4.0] - 2026-08-14
+
+### Added
+
+- OpenCode Zen support: the proxy now serves both OpenCode Go and OpenCode Zen.
+  Zen models are auto-discovered from `https://opencode.ai/zen/v1/models` (no
+  auth), merged with models.dev metadata, and appear in the catalog and
+  `/v1/models` as `zen/<id>` slugs. Requests route per family — claude/qwen to
+  Anthropic Messages (`/zen/v1/messages`, `x-api-key`), gemini to the Gemini API
+  (`/zen/v1/models/<id>`, `x-goog-api-key`), gpt/grok to the Responses API
+  (`/zen/v1/responses`, relayed verbatim), everything else to
+  chat/completions — with each family's stream translated back to one uniform
+  Responses stream. Auth uses the same key as Go
+  (`OPENCODE_GO_API_KEY` / `opencode-go-api-key` keychain) with the header
+  mapped per family. Zen turns meter with `provider="zen"` so they never count
+  against the Go quota. Free models (`deepseek-v4-flash-free`, `mimo-v2.5-free`,
+  `big-pickle`) need no credits.
+- Usage in the menu bar: `GET /state` gains `usage.go` (OpenCode Go usage
+  polled from `https://opencode.ai/zen/go/v1/usage` with a 60s TTL, `null` on
+  fetch failure), `usage.goLimits` (fixed Go dollar budgets: $60/month,
+  $30/week, $12 per rolling 5 hours), and `usage.zen` (today's turns/tokens and
+  a seven-entry last-7-day token rollup from the local meter), alongside the
+  existing all-provider keys.
+
+## [0.3.1] - 2026-08-14
+
+### Fixed
+
+- Catalog `availability_nux` is emitted in the `{message: string} | null`
+  object form the Codex app schema expects instead of a bare string;
+  string-form nux arriving from upstream records is normalized, with empty
+  strings mapped to `null`.
+
 ## [0.3.0] - 2026-08-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -5,10 +5,12 @@
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![Dependencies: zstandard](https://img.shields.io/badge/dependencies-zstandard-blue.svg)](#)
 
-Use your [OpenCode Go](https://opencode.ai/docs/go) subscription in the [Codex app](https://github.com/openai/codex).
+Use your [OpenCode Go](https://opencode.ai/docs/go) and [OpenCode Zen](https://opencode.ai/zen) access in the [Codex app](https://github.com/openai/codex).
 
 Codex expects a Responses API (`/v1/responses`). OpenCode Go exposes an OpenAI-compatible
-Chat Completions API (`/v1/chat/completions`). This proxy bridges that gap in one local process:
+Chat Completions API (`/v1/chat/completions`), and OpenCode Zen serves GPT, Claude, Gemini,
+Grok, DeepSeek, GLM, Kimi, and Qwen models over four different API surfaces. This proxy
+bridges both in one local process:
 
 ```text
 Codex app
@@ -17,16 +19,18 @@ Codex app
     ▼
 opencode-go-proxy  ←── localhost:8787, one runtime dep (zstandard)
     │
-    │  POST /v1/chat/completions (Chat Completions API)
+    │  POST per family: chat/completions · responses · messages · models/<id>
     ▼
-OpenCode Go  ────── 13 models: DeepSeek, GLM, Kimi, MiMo, MiniMax, Qwen
+OpenCode Go / OpenCode Zen  ── 13 open Go models · GPT, Claude, Gemini, Grok, DeepSeek, GLM, Kimi, Qwen
 ```
 
 ## Why
 
 OpenCode Go is $5 for the first month, then $10/month. You get access to 13 open coding models
-hosted in the US, EU, and Singapore. Codex is a great agent but doesn't speak Chat Completions
-natively — it requires Responses-shaped providers. This proxy fixes that.
+hosted in the US, EU, and Singapore. OpenCode Zen is the pay-as-you-go gateway on the same
+account, with frontier models — GPT, Claude, Gemini, Grok — alongside the open ones. Codex is a
+great agent but doesn't speak Chat Completions natively — it requires Responses-shaped providers.
+This proxy fixes that for both.
 
 ## Quick start
 
@@ -126,10 +130,12 @@ codex -p kimi-k2.7-code
 
 The proxy picks the upstream model based on what Codex sends:
 
-1. If the model slug is in the [alias map](src/opencode_go_proxy/protocol.py), it's mapped
+1. If the model slug is `zen/`-prefixed, it routes to the OpenCode Zen gateway
+   instead (see [OpenCode Zen](#opencode-zen)); the prefix wins over everything below.
+2. If the model slug is in the [alias map](src/opencode_go_proxy/protocol.py), it's mapped
    (e.g. `gpt-5.5` → `deepseek-v4-pro`).
-2. If the model slug is a known OpenCode Go model (from the catalog), it's used as-is.
-3. Otherwise, it falls back to `deepseek-v4-flash`.
+3. If the model slug is a known OpenCode Go model (from the catalog), it's used as-is.
+4. Otherwise, it falls back to `deepseek-v4-flash`.
 
 When images are present in a turn with tools, the proxy captions the latest image
 (older ones are stubbed) and routes the main turn to your configured model. Image
@@ -149,6 +155,47 @@ engine with `CODEX_IMAGE_MODEL` or `OPENCODE_GO_PROXY_CAPTION_MODEL` (a model sl
 `OPENCODE_GO_PROXY_VISION_LOCAL_BASE_URL` / `OPENCODE_GO_PROXY_VISION_LOCAL_MODEL`.
 Disable `detail: low` with `OPENCODE_GO_PROXY_CAPTION_DETAIL=none` (a rejected detail
 value also falls back to a `sips`-downscaled image with no detail).
+
+## OpenCode Zen
+
+Since 0.4.0 the proxy also serves [OpenCode Zen](https://opencode.ai/zen), the
+pay-as-you-go gateway with GPT, Claude, Gemini, Grok, DeepSeek, GLM, Kimi, and Qwen
+models. Zen models are auto-discovered from `https://opencode.ai/zen/v1/models` (no
+auth), merged with models.dev metadata, and appear in the catalog and `/v1/models`
+as `zen/<id>` slugs (e.g. `zen/claude-sonnet-4-5`). Point a Codex profile at one the
+same way you do Go models:
+
+```toml
+[profiles.claude-sonnet-4-5]
+model_provider = "opencode-go"
+model = "zen/claude-sonnet-4-5"
+model_context_window = 200000
+approval_policy = "untrusted"
+sandbox_mode = "workspace-write"
+features = { memories = false }
+```
+
+Requests route by model family, translated from the Responses API the proxy always
+speaks to the surface the gateway expects:
+
+| Model ids | Upstream surface | Auth header |
+|-----------|------------------|-------------|
+| `claude-*`, `qwen*` | `/zen/v1/messages` (Anthropic Messages) | `x-api-key` |
+| `gemini-*` | `/zen/v1/models/<id>` (Gemini API) | `x-goog-api-key` |
+| `gpt-*`, `grok-*` | `/zen/v1/responses` (Responses API, verbatim) | `Authorization: Bearer` |
+| everything else | `/zen/v1/chat/completions` | `Authorization: Bearer` |
+
+The proxy resolves the same key as Go — `$OPENCODE_GO_API_KEY` or the macOS keychain
+entry `opencode-go-api-key` — and maps the auth header per family. Zen turns meter
+with `provider="zen"`, so they never count against your Go quota.
+
+Free models need no credits: `deepseek-v4-flash-free`, `mimo-v2.5-free`, and
+`big-pickle` are always available.
+
+The menu bar app shows Go usage polled from `https://opencode.ai/zen/go/v1/usage`
+(60s cache) next to the fixed Go plan limits ($60/month, $30/week, $12 per rolling
+5 hours), and a Zen rollup of today's turns/tokens and the last 7 days from the
+local usage meter.
 
 ## API key
 
@@ -182,6 +229,7 @@ See the [lazycodex docs](https://github.com/code-yeongyu/oh-my-openagent) for se
 
 ## Features
 
+- OpenCode Zen support: auto-discovered `zen/<id>` catalog merged with models.dev metadata, per-family wire translation (Anthropic Messages / Gemini / Responses / chat-completions) with per-family auth header mapping, free models, and `provider="zen"` metering
 - Responses `input` to chat `messages` translation
 - `instructions` and `developer` roles mapped to system messages
 - Function tool schema passthrough
@@ -316,11 +364,34 @@ curl http://127.0.0.1:8787/state
       { "date": "2026-08-09", "tokens": 1800 },
       { "date": "2026-08-10", "tokens": 2700 },
       { "date": "2026-08-11", "tokens": 3456 }
-    ]
+    ],
+    "go": {
+      "rolling": { "...": "..." },
+      "weekly": { "...": "..." },
+      "monthly": { "...": "..." }
+    },
+    "goLimits": {
+      "monthlyDollars": 60,
+      "weeklyDollars": 30,
+      "rolling5hDollars": 12
+    },
+    "zen": {
+      "todayTurns": 3,
+      "todayTokens": 812,
+      "last7d": [0, 0, 0, 0, 1200, 400, 812]
+    }
   },
   "model": "deepseek-v4-flash"
 }
 ```
+
+`usage.go` is the raw response of `GET https://opencode.ai/zen/go/v1/usage`
+(`rolling` / `weekly` / `monthly` windows), TTL-cached for 60s and `null` when
+the fetch fails. `usage.goLimits` holds the fixed Go dollar budgets the menu bar
+renders next to it. `usage.zen` is the Zen-only rollup — turns and tokens for
+today plus a seven-entry daily token list — from the local usage meter; the
+legacy `todayTurns` / `todayTokens` / `last7d` keys stay as the all-provider
+totals.
 
 Missing or corrupt meter/quota files degrade to zeros or `null`; the endpoint
 always returns this shape.

--- a/macos/MenuBarApp/Sources/OpenCodeGoMenuBar/AppDelegate.swift
+++ b/macos/MenuBarApp/Sources/OpenCodeGoMenuBar/AppDelegate.swift
@@ -15,6 +15,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var configLabel: NSMenuItem!
     private var configToggleItem: NSMenuItem!
     private var usageBarItems: [NSMenuItem] = []
+    private var usageSectionItem: NSMenuItem!
+    private var goLimitsLabel: NSMenuItem!
+    private var goUsageLabel: NSMenuItem!
+    private var zenTodayLabel: NSMenuItem!
+    private var zenBarItems: [NSMenuItem] = []
     private var toggleItem: NSMenuItem!
     private var timer: Timer?
 
@@ -94,6 +99,29 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         resetLabel = NSMenuItem(title: "", action: nil, keyEquivalent: "")
         resetLabel.isEnabled = false
         menu.addItem(resetLabel)
+
+        usageSectionItem = NSMenuItem(title: "Usage", action: nil, keyEquivalent: "")
+        usageSectionItem.isEnabled = false
+        menu.addItem(usageSectionItem)
+
+        goLimitsLabel = NSMenuItem(title: "", action: nil, keyEquivalent: "")
+        goLimitsLabel.isEnabled = false
+        menu.addItem(goLimitsLabel)
+
+        goUsageLabel = NSMenuItem(title: "", action: nil, keyEquivalent: "")
+        goUsageLabel.isEnabled = false
+        menu.addItem(goUsageLabel)
+
+        zenTodayLabel = NSMenuItem(title: "", action: nil, keyEquivalent: "")
+        zenTodayLabel.isEnabled = false
+        menu.addItem(zenTodayLabel)
+
+        for _ in 0..<7 {
+            let item = NSMenuItem(title: "", action: nil, keyEquivalent: "")
+            item.isEnabled = false
+            zenBarItems.append(item)
+            menu.addItem(item)
+        }
 
         todayLabel = NSMenuItem(title: "", action: nil, keyEquivalent: "")
         todayLabel.isEnabled = false
@@ -198,6 +226,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             resetLabel.title = text ?? ""
             resetLabel.isHidden = text == nil
         }
+        let usage = serverState?.usage
+        if let usageSectionItem {
+            usageSectionItem.isHidden = usage?.go == nil && usage?.goLimits == nil && usage?.zen == nil
+        }
+        if let goLimitsLabel {
+            goLimitsLabel.title = Self.goLimitsText(usage?.goLimits) ?? ""
+            goLimitsLabel.isHidden = usage?.goLimits == nil
+        }
+        if let goUsageLabel {
+            goUsageLabel.title = Self.goUsageText(usage?.go) ?? ""
+            goUsageLabel.isHidden = usage?.go == nil
+        }
+        if let zenTodayLabel {
+            zenTodayLabel.title = Self.zenTodayText(usage?.zen) ?? ""
+            zenTodayLabel.isHidden = usage?.zen == nil
+        }
+        updateZenBars(usage?.zen)
         if let todayLabel {
             todayLabel.title = Self.todayText(serverState?.usage)
         }
@@ -254,6 +299,35 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
+    /// Zen 7-day bars. Zen usage carries no per-day dates, so weekdays are
+    /// computed relative to today (oldest-first counts, today last).
+    private func updateZenBars(_ zen: ZenUsage?) {
+        guard let zen else {
+            for item in zenBarItems {
+                item.title = "—"
+            }
+            return
+        }
+        let days = zen.last7d
+        let maxTokens = days.max() ?? 0
+        for (index, item) in zenBarItems.enumerated() {
+            let offset = days.count - 1 - index
+            guard offset >= 0, offset < days.count else {
+                item.title = "—"
+                continue
+            }
+            let tokens = days[offset]
+            let date = Calendar.current.date(byAdding: .day, value: -offset, to: Date()) ?? Date()
+            let weekday = Self.weekdayFormatter.string(from: date)
+            var bar = ""
+            if tokens > 0 {
+                let count = max(1, Int(ceil(Double(tokens) / Double(max(1, maxTokens)) * 8)))
+                bar = String(repeating: "█", count: count)
+            }
+            item.title = "\(weekday) \(bar) \(Self.formatTokens(tokens))"
+        }
+    }
+
     private static func displayUpstream(_ raw: String?) -> String {
         guard let raw, !raw.isEmpty else { return "—" }
         var value = raw
@@ -274,6 +348,47 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private static func todayText(_ usage: UsageSummary?) -> String {
         guard let usage else { return "Today —" }
         return "Today \(usage.todayTurns) turns · \(formatTokens(usage.todayTokens)) tok"
+    }
+
+    private static func goLimitsText(_ limits: GoLimits?) -> String? {
+        guard let limits else { return nil }
+        return "Go limits: $\(limits.monthlyDollars)/mo · $\(limits.weeklyDollars)/wk · $\(limits.rolling5hDollars)/5h"
+    }
+
+    private static func goUsageText(_ go: GoUsage?) -> String? {
+        guard let go else { return nil }
+        var parts: [String] = []
+        if let rolling = go.rolling {
+            parts.append(Self.windowText(rolling, label: "rolling"))
+            if let reset = resetText(rolling.resetsAt) {
+                parts.append(Self.lowercasedFirst(reset))
+            }
+        }
+        if let weekly = go.weekly {
+            parts.append(Self.windowText(weekly, label: "wk"))
+        }
+        if let monthly = go.monthly {
+            parts.append(Self.windowText(monthly, label: "mo"))
+        }
+        return "Go usage: " + parts.joined(separator: " · ")
+    }
+
+    private static func windowText(_ window: GoWindow, label: String) -> String {
+        var text = window.percent.map { "\($0)% \(label)" } ?? "\(label) —"
+        if !window.status.isEmpty && window.status != "ok" {
+            text += " (\(window.status))"
+        }
+        return text
+    }
+
+    private static func zenTodayText(_ zen: ZenUsage?) -> String? {
+        guard let zen else { return nil }
+        return "Zen today: \(zen.todayTurns) turns · \(formatTokens(zen.todayTokens)) tok"
+    }
+
+    private static func lowercasedFirst(_ text: String) -> String {
+        guard let first = text.first else { return text }
+        return first.lowercased() + text.dropFirst()
     }
 
     private static func resetText(_ resetAt: String?) -> String? {

--- a/macos/MenuBarApp/Sources/OpenCodeGoMenuBar/ServerState.swift
+++ b/macos/MenuBarApp/Sources/OpenCodeGoMenuBar/ServerState.swift
@@ -21,11 +21,47 @@ struct UsageSummary: Decodable, Equatable {
     let todayTurns: Int
     let todayTokens: Int
     let last7d: [UsageDay]
+    /// Zen contract additions (0.4.0). Optional so a pre-0.4.0 proxy that
+    /// omits these keys still decodes: synthesized Decodable treats a missing
+    /// or null optional key as nil.
+    let go: GoUsage?
+    let goLimits: GoLimits?
+    let zen: ZenUsage?
 }
 
 struct UsageDay: Decodable, Equatable {
     let date: String
     let tokens: Int
+}
+
+/// Go subscription windows from the Zen usage endpoint
+/// ({"rolling": {...}, "weekly": {...}, "monthly": {...}}).
+struct GoUsage: Decodable, Equatable {
+    let rolling: GoWindow?
+    let weekly: GoWindow?
+    let monthly: GoWindow?
+}
+
+struct GoWindow: Decodable, Equatable {
+    let status: String
+    let percent: Int?
+    let resetsAt: String?
+}
+
+/// Go plan dollar limits (fixed per the Zen contract).
+struct GoLimits: Decodable, Equatable {
+    let monthlyDollars: Int
+    let weeklyDollars: Int
+    let rolling5hDollars: Int
+    let subscriptionMonthlyDollars: Int
+}
+
+/// Zen-metered usage: today's rollup plus seven plain token counts
+/// (oldest first, today last).
+struct ZenUsage: Decodable, Equatable {
+    let todayTurns: Int
+    let todayTokens: Int
+    let last7d: [Int]
 }
 
 enum StateFetcher {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "opencode-go-proxy"
-version = "0.3.0"
+version = "0.4.0"
 description = "Use your OpenCode Go subscription in Codex — local Responses-to-Chat-Completions bridge"
 readme = "README.md"
 authors = [{ name = "Kartik Kabadi", email = "1kartikkabadi1@gmail.com" }]

--- a/src/opencode_go_proxy/__init__.py
+++ b/src/opencode_go_proxy/__init__.py
@@ -2,5 +2,5 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 

--- a/src/opencode_go_proxy/app.py
+++ b/src/opencode_go_proxy/app.py
@@ -436,8 +436,12 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _refresh_catalog_in_background() -> None:
-    """Run the TTL-gated runtime catalog refresh; failures are logged, never fatal."""
+CATALOG_REFRESH_INTERVAL_HOURS = 6
+
+
+def _refresh_catalog_once(reason: str) -> None:
+    """Run one TTL-gated runtime catalog refresh; failures are logged, never fatal."""
+    trace("catalog.refresh.start", reason=reason)
     try:
         from opencode_go_proxy import catalog as _catalog
         from opencode_go_proxy.zen_catalog import capture_zen_models
@@ -449,6 +453,48 @@ def _refresh_catalog_in_background() -> None:
         _catalog.render_merged_catalog()
     except Exception as exc:  # noqa: BLE001 - background refresh is best-effort
         trace("catalog.refresh.skipped", error=str(exc))
+
+
+def _refresh_catalog_in_background() -> None:
+    """Run the startup catalog refresh in a daemon thread; failures are logged, never fatal."""
+    _refresh_catalog_once(reason="startup")
+
+
+def _catalog_refresh_enabled() -> bool:
+    from opencode_go_proxy import catalog as _catalog
+
+    return os.environ.get(_catalog.CATALOG_REFRESH_ENV) != "0"
+
+
+def _refresh_catalog_daemon(interval_hours: float = CATALOG_REFRESH_INTERVAL_HOURS) -> None:
+    """Re-run the catalog refresh on an interval until the process exits.
+
+    The refresh is TTL-gated and best-effort, so each tick is cheap: a fresh
+    compact skips discovery entirely, and a stale one issues a conditional GET
+    against models.dev. The thread is daemon=True, so it dies with the
+    process; when catalog refresh is disabled via OPENCODE_GO_CATALOG_REFRESH
+    the loop stays quiet.
+    """
+    while True:
+        time.sleep(interval_hours * 3600)
+        if not _catalog_refresh_enabled():
+            continue
+        trace("catalog.refresh.tick", interval_hours=interval_hours)
+        _refresh_catalog_once(reason="timer")
+
+
+def _start_catalog_refresh() -> None:
+    """Start the startup refresh plus the interval timer, both daemon threads.
+
+    The startup refresh always runs (refresh_catalog itself self-gates on the
+    env); the timer only when catalog refresh is enabled. daemon=True lets both
+    die with the process.
+    """
+    threading.Thread(target=_refresh_catalog_in_background, daemon=True, name="catalog-refresh").start()
+    if _catalog_refresh_enabled():
+        threading.Thread(
+            target=_refresh_catalog_daemon, daemon=True, name="catalog-refresh-timer"
+        ).start()
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -532,8 +578,9 @@ def main(argv: list[str] | None = None) -> None:
     except Exception as exc:  # noqa: BLE001 - startup catalog render is best-effort
         trace("catalog.refresh.skipped", error=str(exc))
     # The full refresh may fetch models.dev (up to a 10s timeout); run it in
-    # the background so startup never blocks on the network.
-    threading.Thread(target=_refresh_catalog_in_background, daemon=True, name="catalog-refresh").start()
+    # the background so startup never blocks on the network, and keep a
+    # low-frequency timer re-running it (both threads daemon=True).
+    _start_catalog_refresh()
     if args.timeout_sec <= 0:
         sys.stderr.write(f"error: --timeout-sec must be positive, got {args.timeout_sec}\n")
         sys.exit(2)

--- a/src/opencode_go_proxy/app.py
+++ b/src/opencode_go_proxy/app.py
@@ -148,6 +148,17 @@ class ResponsesProxyHandler(BaseHTTPRequestHandler):
     def _error_payload(exc: ProxyError) -> Json:
         return {"error": {"type": exc.error_type or "proxy_error", "message": exc.message}}
 
+    def _send_proxy_error(self, exc: ProxyError) -> None:
+        """Write the proxy error envelope, forwarding upstream retry-after.
+
+        Only the upstream's retry-after header is copied (lowercase key); the
+        rest of the upstream response stays out of the envelope.
+        """
+        headers = None
+        if exc.headers and exc.headers.get("retry-after"):
+            headers = {"retry-after": exc.headers["retry-after"]}
+        self._send_json(self._error_payload(exc), status=exc.status, headers=headers)
+
     def _reject_websocket_upgrade(self) -> bool:
         """Reject a realtime WebSocket upgrade with HTTP/1.1 426.
 
@@ -179,7 +190,7 @@ class ResponsesProxyHandler(BaseHTTPRequestHandler):
             self._guard_request()
         except ProxyError as exc:
             trace("request.failed", status=exc.status, message=exc.message)
-            self._send_json(self._error_payload(exc), status=exc.status)
+            self._send_proxy_error(exc)
             return
         if self.path in {"/health", "/v1/health"}:
             self._send_json({"status": "ok"})
@@ -267,7 +278,7 @@ class ResponsesProxyHandler(BaseHTTPRequestHandler):
                 self._send_json(response)
         except ProxyError as exc:
             trace("request.failed", request_id=request_id, status=exc.status, message=exc.message)
-            self._send_json(self._error_payload(exc), status=exc.status)
+            self._send_proxy_error(exc)
         except BrokenPipeError:
             trace("client.disconnected", request_id=request_id, message="client closed connection during stream")
         except Exception as exc:  # pragma: no cover - defensive crash trace  # noqa: BLE001
@@ -304,10 +315,12 @@ class ResponsesProxyHandler(BaseHTTPRequestHandler):
             raise ProxyError(HTTPStatus.BAD_REQUEST, "request body must be a JSON object")
         return value
 
-    def _send_json(self, payload: Json, status: HTTPStatus = HTTPStatus.OK) -> None:
+    def _send_json(self, payload: Json, status: HTTPStatus = HTTPStatus.OK, headers: dict[str, str] | None = None) -> None:
         raw = json.dumps(payload, separators=(",",":")).encode("utf-8")
         self.send_response(status)
         self.send_header("content-type", "application/json")
+        for name, value in (headers or {}).items():
+            self.send_header(name, value)
         self.send_header("content-length", str(len(raw)))
         self.end_headers()
         self.wfile.write(raw)
@@ -407,13 +420,15 @@ def handle_chat_completions_request(handler: ResponsesProxyHandler, payload: Jso
         handle_chat_stream_passthrough(payload, config, request_id, handler)
         return
     started = time.time()
-    status, body, retries, content_type = call_upstream_chat_verbatim(payload, config, request_id)
+    status, body, retries, content_type, retry_after = call_upstream_chat_verbatim(payload, config, request_id)
     record_usage_event(
         model=payload.get("model") or DEFAULT_MODEL, status=status,
         duration_ms=int((time.time() - started) * 1000), retries=retries or None,
     )
     handler.send_response(status)
     handler.send_header("content-type", content_type or "application/json")
+    if retry_after:
+        handler.send_header("retry-after", retry_after)
     handler.send_header("content-length", str(len(body)))
     handler.end_headers()
     handler.wfile.write(body)

--- a/src/opencode_go_proxy/app.py
+++ b/src/opencode_go_proxy/app.py
@@ -52,6 +52,11 @@ from .upstream import (
     usage_tokens,
 )
 from .vision import caption_images_in_messages, is_image_rejection_status
+from .zen_upstream import (
+    call_zen_responses,
+    handle_zen_chat_request,
+    handle_zen_responses_request,
+)
 
 Json = dict[str, Any]
 
@@ -222,20 +227,25 @@ class ResponsesProxyHandler(BaseHTTPRequestHandler):
             check_content_type(self.headers.get("content-type"))
             config = self._config()
             payload = self._read_json(config)
+            model = payload.get("model") or DEFAULT_MODEL
             trace(
                 "request.received",
                 request_id=request_id,
                 path=self.path,
-                model=payload.get("model"),
+                model=model,
                 stream=payload.get("stream", False),
             )
             if path in CHAT_COMPLETIONS_PATHS:
                 handle_chat_completions_request(self, payload, config, request_id)
-            elif path in RESPONSES_PATHS and route_target(payload.get("model") or DEFAULT_MODEL) == "native":
+            elif path in RESPONSES_PATHS and route_target(model) == "native":
                 # Native models relay whole to the ChatGPT backend: the body,
                 # the client's own auth, and the stream are forwarded verbatim
                 # and never touch the OpenCode Go key or alias logic.
                 relay_native_request(self, payload, config, request_id)
+            elif path in RESPONSES_PATHS and route_target(model) == "zen":
+                # Zen models translate per wire family inside the zen client;
+                # they must never reach the opencode-go translation path.
+                handle_zen_responses_request(self, payload, config, request_id)
             elif payload.get("stream") is True:
                 # Real streaming: send SSE headers, then stream from upstream in real-time.
                 self.send_response(HTTPStatus.OK)
@@ -306,6 +316,10 @@ class ResponsesProxyHandler(BaseHTTPRequestHandler):
 def handle_responses_request(payload: Json, config: ProxyConfig, request_id: str) -> Json:
     started = time.time()
     session_model = payload.get("model") or DEFAULT_MODEL
+    if route_target(session_model) == "zen":
+        # Zen models never enter the opencode-go translation path: the zen
+        # client translates per wire family (and meters provider="zen").
+        return call_zen_responses(payload, config, request_id)
     payload = inject_session_model(payload, session_model)
     chat_payload, request_model, conversion_stats = responses_payload_to_chat_payload(payload)
 
@@ -384,6 +398,11 @@ def handle_chat_completions_request(handler: ResponsesProxyHandler, payload: Jso
     unchanged. A missing key surfaces the same 401 proxy error the responses
     path uses.
     """
+    if route_target(payload.get("model") or DEFAULT_MODEL) == "zen":
+        # Zen models relay to the zen chat-completions surface with the zen
+        # key and base; the opencode-go upstream is never involved.
+        handle_zen_chat_request(handler, payload, config, request_id)
+        return
     if payload.get("stream") is True:
         handle_chat_stream_passthrough(payload, config, request_id, handler)
         return
@@ -421,7 +440,11 @@ def _refresh_catalog_in_background() -> None:
     """Run the TTL-gated runtime catalog refresh; failures are logged, never fatal."""
     try:
         from opencode_go_proxy import catalog as _catalog
+        from opencode_go_proxy.zen_catalog import capture_zen_models
 
+        # Zen capture is TTL-gated and never raises (network failure falls back
+        # to cache); without it the merged catalog has no zen/ slugs.
+        capture_zen_models()
         _catalog.refresh_runtime_catalog()
         _catalog.render_merged_catalog()
     except Exception as exc:  # noqa: BLE001 - background refresh is best-effort

--- a/src/opencode_go_proxy/app.py
+++ b/src/opencode_go_proxy/app.py
@@ -22,6 +22,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
 
 from . import __version__
+from .compaction import COMPACT_PATHS, handle_compaction, has_compaction_trigger
 from .config import ProxyConfig, resolve_chat_base_url
 from .errors import ProxyError
 from .guards import check_browser_origin, check_content_type, check_host
@@ -246,6 +247,15 @@ class ResponsesProxyHandler(BaseHTTPRequestHandler):
                 model=model,
                 stream=payload.get("stream", False),
             )
+            # Remote compaction (v1: the dedicated /responses/compact path;
+            # v2: a responses request whose input ends in a compaction trigger
+            # item). Native models fall through to the ChatGPT backend relay,
+            # which handles compaction itself.
+            if path in COMPACT_PATHS or (
+                path in RESPONSES_PATHS and has_compaction_trigger(payload)
+            ) and route_target(model) != "native":
+                handle_compaction(self, payload, config, request_id, path=path)
+                return
             if path in CHAT_COMPLETIONS_PATHS:
                 handle_chat_completions_request(self, payload, config, request_id)
             elif path in RESPONSES_PATHS and route_target(model) == "native":

--- a/src/opencode_go_proxy/catalog.py
+++ b/src/opencode_go_proxy/catalog.py
@@ -419,7 +419,7 @@ def announced_models_path() -> str:
 
 
 def merged_models_path() -> str:
-    """Path of the merged native + opencode-go catalog under the state dir."""
+    """Path of the merged native + opencode-go + zen catalog under the state dir."""
     return os.path.join(state_dir(), MERGE_CATALOG_NAME)
 
 
@@ -791,6 +791,35 @@ def _full_native_record(entry: Json) -> Json:
     return full
 
 
+def _zen_merged_records() -> list[Json]:
+    """Full-shape records for captured zen models, slug-prefixed zen/<id>.
+
+    Built straight from the canonical defaults like _full_native_record, so
+    every key Codex reads is present. The zen family travels as an explicit
+    "family" key on the state record (not part of the canonical shape; stored
+    for future display), and availability_nux stays None (the object form the
+    app schema allows) so zen models never announce.
+    """
+    from .zen_catalog import zen_families, zen_model_ids
+
+    families = zen_families()
+    records = []
+    for model_id in sorted(zen_model_ids()):
+        slug = f"zen/{model_id}"
+        full = _canonical_model_defaults()
+        full["slug"] = slug
+        full["display_name"] = model_id
+        full["description"] = f"Zen model {model_id} served through opencode.ai/zen."
+        full["comp_hash"] = _comp_hash_for(slug)
+        full["family"] = families.get(model_id)
+        context = full["context_window"]
+        full["auto_compact_token_limit"] = round(context * 0.9)
+        full["base_instructions"] = ""
+        full["model_messages"] = model_messages("", full["display_name"], context, full)
+        records.append(full)
+    return records
+
+
 def _clamp_efforts(models: list[Json], native_efforts: set[str]) -> list[Json]:
     """Drop opencode-go reasoning levels whose effort the native capture lacks.
 
@@ -819,8 +848,11 @@ def render_merged_catalog() -> dict:
 
     Native entries keep their captured slugs; opencode-go entries keep bare
     slugs and their reasoning levels are clamped to the native effort
-    vocabulary. The opencode-go side runs the same seed/discovery/overlay
-    pipeline as the runtime catalog. Written under the state dir.
+    vocabulary; zen entries are slug-prefixed zen/<id> with their family on
+    the record. The opencode-go side runs the same seed/discovery/overlay
+    pipeline as the runtime catalog. Zen capture itself is TTL-gated and runs
+    outside this render (app layer), which reads only the zen cache files, so
+    this function stays network-free. Written under the state dir.
     """
     from .native_models import load_native_capture, native_effort_vocabulary
 
@@ -839,6 +871,7 @@ def render_merged_catalog() -> dict:
     native = load_native_capture()
     models = [_full_native_record(entry) for entry in native.get("models", [])]
     models.extend(_clamp_efforts(rendered.get("models", []), native_effort_vocabulary(native)))
+    models.extend(_zen_merged_records())
     merged = {
         "fetched_at": rendered.get("fetched_at", compact["fetched_at"]),
         "etag": rendered.get("etag", compact["etag"]),

--- a/src/opencode_go_proxy/catalog.py
+++ b/src/opencode_go_proxy/catalog.py
@@ -612,6 +612,10 @@ def annotate_announcements(
         slug = str(model.get("slug", ""))
         if slug not in next_announced:
             next_announced[slug] = 0.0 if first_run else now
+        nux = model.get("availability_nux")
+        if isinstance(nux, str):
+            # App schema: availability_nux is {message: str} | null (codex-router contract).
+            model = {**model, "availability_nux": {"message": nux} if nux.strip() else None}
         if model.get("availability_nux") or slug in curated_slugs:
             result.append(model)
             continue
@@ -619,7 +623,7 @@ def annotate_announcements(
         if seen == 0 or now - seen >= AUTO_ANNOUNCE_WINDOW_SECONDS:
             result.append(model)
         else:
-            result.append({**model, "availability_nux": auto_announcement_copy(model)})
+            result.append({**model, "availability_nux": {"message": auto_announcement_copy(model)}})
     return result, next_announced
 
 

--- a/src/opencode_go_proxy/catalog.py
+++ b/src/opencode_go_proxy/catalog.py
@@ -8,7 +8,9 @@ opencode provider; discovery additively merges those entries into the seed.
 The runtime pipeline is layered:
 
 1. Seed/merge: state-dir compact (else checked-in seed) plus models.dev
-   discovery, TTL-gated so a fresh catalog never hits the network.
+   discovery, TTL-gated so a fresh catalog never hits the network and
+   conditional-GET'd (If-None-Match on the stored ETag) so an unchanged
+   catalog is never re-downloaded.
 2. Overlay: user-models.json overrides (add / hide / edit display), then
    availability announcements, then hidden-model flags.
 3. Render: the overlay result is projected through the canonical model shape
@@ -23,16 +25,19 @@ the explicit `refresh-catalog` CLI instead.
 from __future__ import annotations
 
 import datetime
+import hashlib
 import json
 import os
 import tempfile
 import time
 import urllib.error
 import urllib.request
+from http import HTTPStatus
 from typing import Any
 
 from . import __version__
 from .meter import state_dir
+from .trace import trace
 
 Json = dict[str, Any]
 
@@ -185,32 +190,55 @@ class CatalogDiscoveryError(Exception):
     """Raised when the models.dev catalog cannot be fetched or parsed."""
 
 
-def discover_models(timeout: int = 10) -> list[dict]:
-    """Return model dicts from models.dev whose providerID is "opencode".
+class CatalogNotModified(CatalogDiscoveryError):
+    """Raised when models.dev answers 304 to a conditional GET.
 
-    Each returned dict is a models.dev model entry (id, name, description,
-    context/modalities/reasoning/cost when present). models.dev rejects
-    the default urllib User-Agent with 403, so the fetch sends an identifying
-    UA. Raises CatalogDiscoveryError on network failure or malformed JSON.
+    Carries the etag that was sent so the caller can trace the cached-refresh
+    event and keep its existing compact untouched.
     """
-    request = urllib.request.Request(
-        MODELS_DEV_URL, headers={"User-Agent": f"opencode-go-proxy/{__version__}"}
-    )
+
+    def __init__(self, etag: str | None) -> None:
+        super().__init__(f"catalog not modified (304) for etag {etag!r}")
+        self.etag = etag
+
+
+def discover_models(timeout: int = 10, etag: str | None = None) -> tuple[list[dict], str | None]:
+    """Return (models, etag) from models.dev whose providerID is "opencode".
+
+    Each model dict is a models.dev entry (id, name, description,
+    context/modalities/reasoning/cost when present). The second element is the
+    response ETag header (None when the server sends none); the caller stores
+    it in the compact so the next refresh can send it back. When `etag` is
+    given it is sent as If-None-Match, and a 304 answer raises
+    CatalogNotModified so the caller can keep its existing catalog instead of
+    re-downloading. models.dev rejects the default urllib User-Agent with 403,
+    so the fetch sends an identifying UA. Raises CatalogDiscoveryError on
+    network failure or malformed JSON.
+    """
+    headers = {"User-Agent": f"opencode-go-proxy/{__version__}"}
+    if etag:
+        headers["If-None-Match"] = etag
+    request = urllib.request.Request(MODELS_DEV_URL, headers=headers)
     try:
         with urllib.request.urlopen(request, timeout=timeout) as resp:
             payload: Json = json.load(resp)
+            upstream_etag: str | None = resp.headers.get("ETag")
+    except urllib.error.HTTPError as exc:
+        if exc.code == HTTPStatus.NOT_MODIFIED:
+            raise CatalogNotModified(etag) from exc
+        raise CatalogDiscoveryError(f"failed to fetch {MODELS_DEV_URL}: {exc}") from exc
     except (urllib.error.URLError, TimeoutError, OSError, json.JSONDecodeError) as exc:
         raise CatalogDiscoveryError(f"failed to fetch {MODELS_DEV_URL}: {exc}") from exc
 
     provider = payload.get("opencode")
     if not isinstance(provider, dict):
-        return []
+        return [], upstream_etag
     models = provider.get("models")
     if isinstance(models, dict):
-        return [entry for entry in models.values() if isinstance(entry, dict)]
+        return [entry for entry in models.values() if isinstance(entry, dict)], upstream_etag
     if isinstance(models, list):
-        return [entry for entry in models if isinstance(entry, dict)]
-    return []
+        return [entry for entry in models if isinstance(entry, dict)], upstream_etag
+    return [], upstream_etag
 
 
 def default_catalog_path() -> str:
@@ -656,6 +684,26 @@ def _render_and_write(compact: dict, catalog_path: str, overlay: bool = False) -
     return rendered
 
 
+def _content_etag(models: list[dict]) -> str:
+    """Weak etag from the serialized model list; stable for identical content.
+
+    Used when models.dev sends no ETag header. The old daily synthetic etag
+    churned the Codex client cache every day even when the catalog never
+    changed, so the fallback is derived from the content itself: the model
+    list serialized deterministically (sorted by slug, sorted keys, compact
+    separators), so an unchanged model set yields the same etag forever.
+    """
+    payload = json.dumps(
+        sorted(
+            [m for m in models if isinstance(m, dict)],
+            key=lambda m: str(m.get("slug", "")),
+        ),
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return f'W/"{hashlib.md5(payload.encode("utf-8")).hexdigest()}"'
+
+
 def refresh_catalog(
     compact_path: str | None = None,
     catalog_path: str | None = None,
@@ -675,6 +723,9 @@ def refresh_catalog(
     Refreshing is skipped when the compact catalog is fresh (fetched_at within
     ttl_hours), when the OPENCODE_GO_CATALOG_REFRESH env var is "0", or when
     discovery fails and a compact catalog already exists (offline fallback).
+    Discovery is a conditional GET: the compact's etag is sent as If-None-Match,
+    and a 304 answer keeps the existing compact and the rendered catalog on
+    disk untouched (only a cached-refresh event is traced).
     """
     if now is None:
         now = datetime.datetime.now(datetime.UTC)
@@ -705,8 +756,29 @@ def refresh_catalog(
                 except ValueError:
                     pass
 
+    existing = _load_if_readable(compact_path)
+    if existing is None:
+        existing = _load_if_readable(seed_path)
+    existing = existing or {}
+
+    stored_etag = existing.get("etag")
+    if not isinstance(stored_etag, str) or not stored_etag:
+        stored_etag = None
+
     try:
-        discovered = discover_models()
+        # force=True bypasses the conditional GET: a forced refresh wants a
+        # fresh copy regardless of the stored etag.
+        discovered, upstream_etag = discover_models(etag=None if force else stored_etag)
+    except CatalogNotModified:
+        trace("catalog.refresh.cached", etag=stored_etag)
+        # 304: models.dev content is unchanged. Keep the existing compact (and
+        # its etag) untouched and skip the re-render; serve the catalog that
+        # is already on disk. Render only in the degenerate case where a
+        # catalog file is missing despite a compact.
+        cached = _load_if_readable(catalog_path)
+        if cached is not None:
+            return cached
+        return _render_and_write(existing, catalog_path, overlay=overlay)
     except CatalogDiscoveryError:
         # Offline first run: fall back to the seed so a fresh install that
         # cannot reach models.dev still renders a valid catalog. Honor an
@@ -716,10 +788,6 @@ def refresh_catalog(
             return _render_and_write(fallback, catalog_path, overlay=overlay)
         raise
 
-    existing = _load_if_readable(compact_path)
-    if existing is None:
-        existing = _load_if_readable(seed_path)
-    existing = existing or {}
     models = list(existing.get("models", []))
     known = {record.get("slug") for record in models if isinstance(record, dict) and record.get("slug")}
     for entry in discovered:
@@ -729,7 +797,10 @@ def refresh_catalog(
             known.add(model_id)
     compact = {
         "fetched_at": iso,
-        "etag": f'W/"opencode-go-models-{now:%Y%m%d}"',
+        # models.dev's real ETag when it sends one, else a content hash: both
+        # are stable while the model set is unchanged, so the Codex client's
+        # catalog cache does not churn on every refresh.
+        "etag": upstream_etag or _content_etag(models),
         "shared_instructions": existing.get("shared_instructions", ""),
         "client_version": existing.get("client_version", ""),
         "models": models,
@@ -883,15 +954,41 @@ def render_merged_catalog() -> dict:
 
 
 
+_MERGED_SLUGS_CACHE: tuple[str, int | None, list[str]] | None = None
+
+
 def merged_model_slugs() -> list[str]:
-    """Slug list from the merged catalog; empty when it has not been rendered."""
+    """Slug list from the merged catalog, cached by file mtime.
+
+    Mirrors protocol.known_models(): the menu bar polls /v1/models every 3s,
+    and the mtime key turns each poll into one stat instead of a full file
+    read. A rewritten merged-models.json (new mtime) makes the next call
+    re-read without a restart. Empty when the file has not been rendered.
+    """
+    global _MERGED_SLUGS_CACHE
+
+    path = merged_models_path()
     try:
-        with open(merged_models_path()) as handle:
-            payload = json.load(handle)
-    except (OSError, json.JSONDecodeError):
-        return []
-    models = payload.get("models", []) if isinstance(payload, dict) else []
-    return sorted({str(m["slug"]) for m in models if isinstance(m, dict) and m.get("slug")})
+        mtime = os.stat(path).st_mtime_ns
+    except OSError:
+        mtime = None
+    if (
+        _MERGED_SLUGS_CACHE is not None
+        and _MERGED_SLUGS_CACHE[0] == path
+        and _MERGED_SLUGS_CACHE[1] == mtime
+    ):
+        return list(_MERGED_SLUGS_CACHE[2])
+    slugs: list[str] = []
+    if mtime is not None:
+        try:
+            with open(path) as handle:
+                payload = json.load(handle)
+        except (OSError, json.JSONDecodeError):
+            payload = None
+        models = payload.get("models", []) if isinstance(payload, dict) else []
+        slugs = sorted({str(m["slug"]) for m in models if isinstance(m, dict) and m.get("slug")})
+    _MERGED_SLUGS_CACHE = (path, mtime, slugs)
+    return slugs
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -931,6 +1028,7 @@ __all__ = [
     "STATE_CATALOG_NAME",
     "STATE_COMPACT_NAME",
     "CatalogDiscoveryError",
+    "CatalogNotModified",
     "annotate_announcements",
     "apply_hidden_models",
     "apply_user_models",

--- a/src/opencode_go_proxy/compaction.py
+++ b/src/opencode_go_proxy/compaction.py
@@ -1,0 +1,348 @@
+"""Native remote-compaction support for the Codex app (v1 and v2).
+
+The Codex desktop app runs compaction turns through the same ``openai_base_url``
+the proxy serves. Two wire families exist:
+
+- v1: POST ``/responses/compact`` (or ``/v1/responses/compact``). The app
+  parses the response's ``output`` items as the replacement conversation
+  history; the summary is delivered as a single
+  ``{"type": "compaction", "encrypted_content": ...}`` output item.
+- v2: a normal ``/responses`` POST whose input ends in a compaction trigger
+  item (``compaction_trigger`` or ``context_compaction``). The app streams the
+  turn and expects exactly one ``context_compaction`` output item followed by
+  ``response.completed``.
+
+Both families summarize the conversation with one non-streaming chat
+completion against the upstream the session's model routes to (opencode-go
+chat completions, or the zen surface for ``zen/`` models), then encode the
+summary with codex-router's ``kcr1:`` prefix + base64 format so a summary
+written here round-trips through history and decodes on the router side (and
+vice versa). The compaction turn is metered like any other routed turn, with
+the summarization call's usage and the provider of the routed model.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import time
+import uuid
+from http import HTTPStatus
+from typing import Any
+
+from .config import ProxyConfig
+from .errors import ProxyError
+from .meter import record_usage_event
+from .protocol import (
+    DEFAULT_MODEL,
+    flatten_content,
+    known_models,
+    new_response_id,
+    output_text_from_items,
+)
+from .routing import normalize_model_slug, route_target
+from .secrets import resolve_api_key
+from .trace import trace
+from .upstream import call_upstream_chat, usage_tokens
+from .zen_upstream import (
+    ZEN_PROVIDER,
+    _build_zen_request,
+    _translate_response,
+    _zen_post,
+    _zen_tokens,
+    bare_zen_id,
+    zen_family_for,
+)
+
+Json = dict[str, Any]
+
+# The dedicated compaction endpoints (v1).
+COMPACT_PATHS = frozenset({"/responses/compact", "/v1/responses/compact"})
+
+# Input item types that mark a v2 remote-compaction request.
+V2_TRIGGER_TYPES = frozenset({"context_compaction", "compaction_trigger"})
+
+# Fixed summarization prompt (codex-router's COMPACT_PROMPT): a checkpoint
+# compaction that produces a handoff summary for the resuming model.
+COMPACT_PROMPT = (
+    "You are performing a CONTEXT CHECKPOINT COMPACTION. Create a handoff summary "
+    "for another language model that will resume the task.\n\n"
+    "Include current progress, key decisions, constraints, user preferences, "
+    "remaining steps, and critical data or references. Be concise, structured, "
+    "and focused on seamless continuation."
+)
+
+# Encrypted-content envelope, matching codex-router's encodeSummary: the
+# literal prefix "kcr1:" followed by base64(utf-8(summary)). A compaction
+# item produced here decodes with codex-router's decodeSummary and vice
+# versa, so history keeps working when the app talks to either proxy.
+COMPACTION_PREFIX = "kcr1:"
+
+# Transcript budget for the summarization input, mirroring codex-router's
+# compactOutput: keep the tail (most recent) of the conversation.
+TRANSCRIPT_BUDGET = 80_000
+
+# When the summarization call returns no text, the compaction item still
+# needs a meaningful payload (mirrors the router's "(no summary available)").
+PLACEHOLDER_SUMMARY = "(no summary available)"
+
+
+def encode_summary(summary: str) -> str:
+    """Encode a summary in the codex-router wire format (``kcr1:`` + base64)."""
+    return COMPACTION_PREFIX + base64.b64encode(summary.encode("utf-8")).decode("ascii")
+
+
+def decode_summary(encrypted_content: Any) -> str | None:
+    """Decode a ``kcr1:``-prefixed summary; None when the value is not ours."""
+    if not isinstance(encrypted_content, str) or not encrypted_content.startswith(COMPACTION_PREFIX):
+        return None
+    try:
+        return base64.b64decode(encrypted_content[len(COMPACTION_PREFIX):], validate=True).decode("utf-8")
+    except (ValueError, UnicodeDecodeError):
+        return None
+
+
+def has_compaction_trigger(payload: Json) -> bool:
+    """True when the request's input ends in a v2 compaction trigger item.
+
+    The app appends the trigger as the LAST input item (codex-rs pushes a
+    ``compaction_trigger`` item after the history), while a normal turn whose
+    history merely CONTAINS a ``context_compaction`` item from an earlier
+    compaction keeps its current user message last. Testing only the last
+    item detects the real request without hijacking every later turn. A
+    malformed payload (missing or non-list input) falls through to the normal
+    path.
+    """
+    input_value = payload.get("input")
+    if not isinstance(input_value, list) or not input_value:
+        return False
+    last = input_value[-1]
+    return isinstance(last, dict) and last.get("type") in V2_TRIGGER_TYPES
+
+
+def render_transcript(input_value: Any, budget: int = TRANSCRIPT_BUDGET) -> str:
+    """Flatten the input items to plain text, skipping trigger items.
+
+    Each item's content is flattened with :func:`protocol.flatten_content` and
+    joined; the result is bounded to the most recent ``budget`` characters
+    (the tail), mirroring codex-router's compactOutput budget.
+    """
+    if isinstance(input_value, str):
+        items: list[Any] = [input_value]
+    elif isinstance(input_value, list):
+        items = input_value
+    else:
+        items = []
+    parts: list[str] = []
+    for item in items:
+        if isinstance(item, dict) and item.get("type") in V2_TRIGGER_TYPES:
+            continue
+        text = flatten_content(item.get("content") if isinstance(item, dict) else item)
+        if text:
+            parts.append(text)
+    transcript = "\n\n".join(parts)
+    if len(transcript) > budget:
+        transcript = transcript[-budget:]
+    return transcript
+
+
+def _chat_text(chat: Json) -> str:
+    """The assistant text of one non-stream chat-completions response."""
+    choices = chat.get("choices")
+    if isinstance(choices, list) and choices and isinstance(choices[0], dict):
+        message = choices[0].get("message")
+        if isinstance(message, dict):
+            content = message.get("content")
+            if isinstance(content, str) and content.strip():
+                return content.strip()
+    return ""
+
+
+def _responses_text(response: Json) -> str:
+    """The output text of one Responses-shaped object."""
+    output_text = response.get("output_text")
+    if isinstance(output_text, str) and output_text.strip():
+        return output_text.strip()
+    return output_text_from_items(response.get("output", [])).strip()
+
+
+def _summarize_go(model: str, transcript: str, config: ProxyConfig, request_id: str) -> tuple[str, Any, Any, Any, int]:
+    """One non-stream opencode-go chat-completions summarization call."""
+    bare = normalize_model_slug(model)
+    if bare not in known_models():
+        bare = DEFAULT_MODEL
+    chat_payload: Json = {
+        "model": bare,
+        "messages": [
+            {"role": "user", "content": transcript},
+            {"role": "user", "content": COMPACT_PROMPT},
+        ],
+        "stream": False,
+    }
+    trace("compaction.summarize", request_id=request_id, target="opencode-go", model=bare, transcript_chars=len(transcript))
+    chat, retries = call_upstream_chat(chat_payload, config, request_id)
+    summary = _chat_text(chat) or PLACEHOLDER_SUMMARY
+    inp, outp, total = usage_tokens(chat.get("usage"))
+    return summary, inp, outp, total, retries
+
+
+def _summarize_zen(model: str, transcript: str, config: ProxyConfig, request_id: str) -> tuple[str, Any, Any, Any, int]:
+    """One non-stream zen summarization call (provider="zen", never double-metered)."""
+    bare_id = bare_zen_id(model)
+    family = zen_family_for(bare_id)
+    api_key = resolve_api_key(config, request_id)
+    zen_payload: Json = {
+        "model": model,
+        "input": [
+            {"type": "message", "role": "user", "content": [{"type": "input_text", "text": transcript}]},
+            {"type": "message", "role": "user", "content": [{"type": "input_text", "text": COMPACT_PROMPT}]},
+        ],
+        "stream": False,
+    }
+    url, body, headers = _build_zen_request(
+        zen_payload, family, bare_id, api_key, stream=False, session_model=model
+    )
+    raw_payload = json.dumps(body, separators=(",", ":")).encode("utf-8")
+    trace("compaction.summarize", request_id=request_id, target="zen", model=bare_id, transcript_chars=len(transcript))
+    value, retries = _zen_post(url, raw_payload, headers, config, request_id)
+    summary = _responses_text(_translate_response(value, family, model)) or PLACEHOLDER_SUMMARY
+    inp, outp, total = _zen_tokens(value, family)
+    return summary, inp, outp, total, retries
+
+
+def _summarize(
+    payload: Json, model: str, config: ProxyConfig, request_id: str
+) -> tuple[str, Any, Any, Any, int]:
+    """Summarize the payload's input with one non-stream completion.
+
+    Returns ``(summary, input_tokens, output_tokens, total_tokens, retries)``;
+    token fields are the upstream's own numbers (None when the upstream sent
+    none). Raises :class:`ProxyError` on upstream failure so the dispatcher
+    surfaces the usual proxy error and the app can retry or fall back.
+    """
+    transcript = render_transcript(payload.get("input"))
+    if route_target(model) == "zen":
+        return _summarize_zen(model, transcript, config, request_id)
+    return _summarize_go(model, transcript, config, request_id)
+
+
+def _compaction_response(model: str, item: Json) -> Json:
+    """The shared v1/v2 non-stream response envelope (Responses shape)."""
+    return {
+        "id": new_response_id(),
+        "object": "response",
+        "created_at": int(time.time()),
+        "status": "completed",
+        "model": model,
+        "output": [item],
+        "usage": None,
+    }
+
+
+def _send_json(handler: Any, payload: Json) -> None:
+    raw = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    handler.send_response(HTTPStatus.OK)
+    handler.send_header("content-type", "application/json")
+    handler.send_header("content-length", str(len(raw)))
+    handler.end_headers()
+    handler.wfile.write(raw)
+    handler.wfile.flush()
+
+
+def _write_compaction_sse(handler: Any, model: str, item: Json) -> None:
+    """Stream the v2 compaction turn: created → added → done → completed.
+
+    Event order mirrors codex-router's writeCompactionSse plus the
+    ``response.output_item.added`` the app's v2 collector expects: the item
+    must be announced before it can be done. Each event carries its
+    ``sequence_number`` like the router's writer.
+    """
+    handler.send_response(HTTPStatus.OK)
+    handler.send_header("content-type", "text/event-stream")
+    handler.send_header("cache-control", "no-cache")
+    handler.end_headers()
+    created = {
+        "id": new_response_id(),
+        "object": "response",
+        "created_at": int(time.time()),
+        "status": "in_progress",
+        "model": model,
+        "output": [],
+        "usage": None,
+    }
+    completed = {**created, "status": "completed", "output": [item]}
+    events: list[tuple[str, Json]] = [
+        ("response.created", {"response": created}),
+        ("response.output_item.added", {"output_index": 0, "item": item}),
+        ("response.output_item.done", {"output_index": 0, "item": item}),
+        ("response.completed", {"response": completed}),
+    ]
+    for sequence, (event_type, data) in enumerate(events):
+        event: Json = {"type": event_type, "sequence_number": sequence, **data}
+        event_data = json.dumps(event, separators=(",", ":"))
+        handler.wfile.write(f"event: {event_type}\ndata: {event_data}\n\n".encode())
+    handler.wfile.write(b"data: [DONE]\n\n")
+    handler.wfile.flush()
+
+
+def handle_compaction(
+    handler: Any,
+    payload: Json,
+    config: ProxyConfig,
+    request_id: str,
+    *,
+    path: str,
+) -> None:
+    """Serve one remote-compaction request (v1 JSON, or v2 stream/JSON).
+
+    The summarization sub-call is metered as the compaction turn itself
+    (provider follows the routed model: opencode-go default or zen), with the
+    upstream usage numbers when present; an upstream failure is metered at the
+    surfaced status and re-raised for the dispatcher's error envelope.
+    """
+    started = time.time()
+    v2 = path not in COMPACT_PATHS
+    model = payload.get("model") or DEFAULT_MODEL
+    provider = ZEN_PROVIDER if route_target(model) == "zen" else None
+    try:
+        summary, inp, outp, total, retries = _summarize(payload, model, config, request_id)
+    except ProxyError as exc:
+        record_usage_event(
+            model=model,
+            status=int(exc.status),
+            duration_ms=int((time.time() - started) * 1000),
+            retries=exc.retries or None,
+            provider=provider,
+        )
+        raise
+    encoded = encode_summary(summary)
+    item: Json = {
+        "type": "context_compaction" if v2 else "compaction",
+        "id": f"cmp_{uuid.uuid4().hex}",
+        "encrypted_content": encoded,
+    }
+    record_usage_event(
+        model=model,
+        status=200,
+        duration_ms=int((time.time() - started) * 1000),
+        input_tokens=inp,
+        output_tokens=outp,
+        total_tokens=total,
+        retries=retries or None,
+        provider=provider,
+    )
+    trace(
+        "compaction.done",
+        request_id=request_id,
+        v2=v2,
+        model=model,
+        summary_chars=len(summary),
+        encrypted_chars=len(encoded),
+    )
+    if not v2:
+        _send_json(handler, _compaction_response(model, item))
+        return
+    if payload.get("stream") is True:
+        _write_compaction_sse(handler, model, item)
+    else:
+        _send_json(handler, _compaction_response(model, item))

--- a/src/opencode_go_proxy/config_manager.py
+++ b/src/opencode_go_proxy/config_manager.py
@@ -40,6 +40,7 @@ module never touches the real ~/.codex/config.toml on its own.
 
 from __future__ import annotations
 
+import datetime
 import json
 import os
 import re
@@ -313,6 +314,24 @@ def _atomic_write(path: str, contents: str) -> None:
         raise
 
 
+def _backup_config(path: str, contents: str) -> str | None:
+    """Snapshot the pre-edit config to config.toml.bak-<UTC timestamp>.
+
+    Called immediately before an actual modification (enable/disable where
+    the new content differs). The microsecond-precision UTC timestamp means
+    every change gets a fresh backup file and earlier snapshots are never
+    overwritten; the write reuses _atomic_write, so the backup lands with
+    mode 0600 and holds the pre-edit content byte-for-byte. Returns the
+    backup path, or None when the file did not exist (nothing to snapshot).
+    """
+    if not os.path.exists(path):
+        return None
+    timestamp = datetime.datetime.now(datetime.UTC).strftime("%Y%m%d-%H%M%S-%f")
+    backup_path = f"{path}.bak-{timestamp}"
+    _atomic_write(backup_path, contents)
+    return backup_path
+
+
 def enable() -> dict[str, object]:
     """Insert the managed block; refuse to clobber user-owned values."""
     path = config_path()
@@ -354,6 +373,7 @@ def enable() -> dict[str, object]:
     rendered = _render(next_root, table_lines)
     changed = rendered != contents
     if changed:
+        _backup_config(path, contents)
         _atomic_write(path, rendered)
     return {
         "action": "enable",
@@ -380,11 +400,13 @@ def disable() -> dict[str, object]:
         return {"action": "disable", "path": path, "changed": False, "file_removed": False}
     cleaned = _without_block(contents)
     if not cleaned.strip():
+        _backup_config(path, contents)
         os.unlink(path)
         return {"action": "disable", "path": path, "changed": True, "file_removed": True}
     root_lines, table_lines = _split_root(cleaned)
     rendered = _render(root_lines, table_lines)
     if rendered != contents:
+        _backup_config(path, contents)
         _atomic_write(path, rendered)
     return {"action": "disable", "path": path, "changed": True, "file_removed": False}
 

--- a/src/opencode_go_proxy/config_manager.py
+++ b/src/opencode_go_proxy/config_manager.py
@@ -16,13 +16,18 @@ config.toml:
     name = "opencode-go"
     base_url = "http://127.0.0.1:8787/v1"
     wire_api = "responses"
+
+    [model_providers.zen]
+    name = "zen"
+    base_url = "http://127.0.0.1:8787/v1"
+    wire_api = "responses"
     # END opencode-go-proxy-managed
 
 The multi_agent_v2 feature block is written only when the installed codex
 binary accepts the flag (probed via `codex debug prompt-input --enable
-multi_agent_v2`); the provider block is omitted entirely when the user
-declares their own [model_providers.opencode-go] table (TOML forbids
-splitting one table across two locations). Semantics mirror codex-router's
+multi_agent_v2`); a provider table is omitted entirely when the user declares
+their own [model_providers.<same-name>] table (TOML forbids splitting one
+table across two locations). Semantics mirror codex-router's
 config-manager: enable never replaces a user-owned openai_base_url or
 model_catalog_json, disable removes only the managed block (and the file when
 the block was its only content), and the Codex Voice realtime keys are added
@@ -176,18 +181,27 @@ def _toml_string(value: str) -> str:
     return json.dumps(value)
 
 
-def _provider_keys_owned(table_lines: list[str]) -> set[str]:
-    """Keys a user's own [model_providers.opencode-go] table already sets."""
-    in_section = False
-    keys: set[str] = set()
+_PROVIDER_TABLE = re.compile(r"^\[model_providers\.([^\]]+)\]$")
+
+
+def _provider_tables_owned(table_lines: list[str]) -> dict[str, set[str]]:
+    """Keys each user-owned [model_providers.<name>] table sets, by provider.
+
+    TOML forbids splitting one table across two locations, so the managed
+    block must omit a provider table entirely when the user declares it
+    anywhere outside the block.
+    """
+    owned: dict[str, set[str]] = {}
+    section: str | None = None
     for line in table_lines:
         stripped = line.strip()
         if stripped.startswith("["):
-            in_section = stripped == "[model_providers.opencode-go]"
+            match = _PROVIDER_TABLE.match(stripped)
+            section = match.group(1) if match else None
             continue
-        if in_section and "=" in stripped and not stripped.startswith("#"):
-            keys.add(stripped.split("=", 1)[0].strip())
-    return keys
+        if section is not None and "=" in stripped and not stripped.startswith("#"):
+            owned.setdefault(section, set()).add(stripped.split("=", 1)[0].strip())
+    return owned
 
 
 def _user_configures_multi_agent_v2(root_lines: list[str], table_lines: list[str]) -> bool:
@@ -215,13 +229,23 @@ def _block_lines(
         lines.append(f"{REALTIME_WS_KEY} = {_toml_string(DEFAULT_REALTIME_WS_BASE_URL)}")
     if multi_agent_v2 and not _user_configures_multi_agent_v2(root_lines, table_lines):
         lines.extend(["", "[features.multi_agent_v2]", "enabled = true"])
-    provider_keys = _provider_keys_owned(table_lines)
-    if not provider_keys:
+    owned = _provider_tables_owned(table_lines)
+    if not owned.get("opencode-go"):
         lines.extend(
             [
                 "",
                 "[model_providers.opencode-go]",
                 'name = "opencode-go"',
+                f"base_url = {_toml_string(base_url)}",
+                'wire_api = "responses"',
+            ]
+        )
+    if not owned.get("zen"):
+        lines.extend(
+            [
+                "",
+                "[model_providers.zen]",
+                'name = "zen"',
                 f"base_url = {_toml_string(base_url)}",
                 'wire_api = "responses"',
             ]
@@ -402,6 +426,7 @@ def status() -> dict[str, object]:
             "model_catalog_json": _root_value(root_lines, "model_catalog_json"),
             "multi_agent_v2": any(line.strip() == "[features.multi_agent_v2]" for line in block_lines),
             "provider_block": any(line.strip() == "[model_providers.opencode-go]" for line in block_lines),
+            "zen_provider_block": any(line.strip() == "[model_providers.zen]" for line in block_lines),
             "voice_keys_user_owned": user_owned,
             "voice_keys_managed": managed_owned,
         }
@@ -441,6 +466,7 @@ def config_cmd(argv: list[str] | None = None) -> int:
                 sys.stdout.write(f"openai_base_url: {report['openai_base_url'] or '(unset)'}\n")
                 sys.stdout.write(f"model_catalog_json: {report['model_catalog_json'] or '(unset)'}\n")
                 sys.stdout.write(f"multi_agent_v2: {'enabled' if report['multi_agent_v2'] else 'not enabled'}\n")
+                sys.stdout.write(f"zen_provider_block: {'enabled' if report['zen_provider_block'] else 'not enabled'}\n")
                 if report["voice_keys_user_owned"]:
                     sys.stdout.write(f"user voice keys: {', '.join(sorted(report['voice_keys_user_owned']))}\n")
                 if report["voice_keys_managed"]:

--- a/src/opencode_go_proxy/errors.py
+++ b/src/opencode_go_proxy/errors.py
@@ -14,6 +14,7 @@ class ProxyError(Exception):
         retries: int = 0,
         upstream_status: int | None = None,
         error_type: str | None = None,
+        headers: dict[str, str] | None = None,
     ) -> None:
         super().__init__(message)
         self.status = status
@@ -26,3 +27,6 @@ class ProxyError(Exception):
         # Rendered as the error type in the JSON envelope; defaults to
         # "proxy_error" at dispatch time.
         self.error_type = error_type
+        # Upstream response headers the proxy forwards on its own error
+        # response (e.g. retry-after on 429); keys are lowercase.
+        self.headers = headers

--- a/src/opencode_go_proxy/meter.py
+++ b/src/opencode_go_proxy/meter.py
@@ -128,6 +128,96 @@ def _iso_at(value: float | None) -> str:
     return instant.isoformat(timespec="milliseconds").replace("+00:00", "Z")
 
 
+_DAY_KEYS = ("inputTokens", "outputTokens")
+
+
+def _event_tokens(event: Json) -> int:
+    """Tokens for one event: totalTokens, or the zero-token estimate when the
+    upstream reported 0 (estimatedInputTokens plus any real output)."""
+    total = _safe_token(event.get("totalTokens"))
+    if total is not None and total > 0:
+        return total
+    estimated = _safe_token(event.get("estimatedInputTokens"))
+    if estimated is not None and estimated > 0:
+        output = _safe_token(event.get("outputTokens")) or 0
+        return estimated + output
+    if total is not None:
+        return total
+    return sum(_safe_token(event.get(key)) or 0 for key in _DAY_KEYS)
+
+
+def _local_day(value: Any, now: datetime.datetime) -> str | None:
+    """ISO day string (YYYY-MM-DD) in ``now``'s timezone for an event ``at``."""
+    if not isinstance(value, str):
+        return None
+    try:
+        instant = datetime.datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    if instant.tzinfo is None:
+        instant = instant.replace(tzinfo=datetime.UTC)
+    return instant.astimezone(now.tzinfo).date().isoformat()
+
+
+def usage_summary(now: datetime.datetime | None = None, provider: str | None = None) -> Json:
+    """Aggregate meter events: today's turns/tokens, 7-day bars, last model.
+
+    Days are bucketed in the caller's local timezone so the menu bar's
+    "today" matches the calendar day the user sees. ``last7d`` is always
+    seven entries (oldest first, including today), zero-filled for quiet
+    days, so the UI renders a stable bar list. ``model`` is the model of the
+    most recent event, or None when the meter file is absent or empty. When
+    ``provider`` is given, only events whose ``provider`` field matches are
+    counted (the zen rollup filters on provider="zen").
+    """
+    now = now or datetime.datetime.now().astimezone()
+    today = now.date().isoformat()
+    days = [(now - datetime.timedelta(days=offset)).date().isoformat() for offset in range(6, -1, -1)]
+    by_day: dict[str, int] = {day: 0 for day in days}
+    today_turns = 0
+    today_tokens = 0
+    last_model: str | None = None
+    try:
+        with open(usage_events_path(), encoding="utf-8") as handle:
+            for line in handle:
+                if not line.strip():
+                    continue
+                try:
+                    event = json.loads(line)
+                except ValueError:
+                    continue
+                if not isinstance(event, dict):
+                    continue
+                if provider is not None and event.get("provider") != provider:
+                    continue
+                day = _local_day(event.get("at"), now)
+                if day is None:
+                    continue
+                tokens = _event_tokens(event)
+                if day in by_day:
+                    by_day[day] += tokens
+                    if day == today:
+                        today_turns += 1
+                        today_tokens += tokens
+                model = event.get("model")
+                if isinstance(model, str) and model:
+                    last_model = model
+    except OSError:
+        # Meter file absent or unreadable: degrade to zeros, never fail the endpoint.
+        return {
+            "todayTurns": 0,
+            "todayTokens": 0,
+            "last7d": [{"date": day, "tokens": 0} for day in days],
+            "model": None,
+        }
+    return {
+        "todayTurns": today_turns,
+        "todayTokens": today_tokens,
+        "last7d": [{"date": day, "tokens": by_day[day]} for day in days],
+        "model": last_model,
+    }
+
+
 def record_usage_event(
     *,
     model: str | None,

--- a/src/opencode_go_proxy/meter.py
+++ b/src/opencode_go_proxy/meter.py
@@ -11,7 +11,9 @@ reference schema - ISO 8601 `at`, camelCase token/duration fields, plus
   `status: 502` plus a `streamAborted` marker and omits token counts, so a
   turn the client saw start but never finish is never counted as a success.
 - An upstream that answered 200 but produced no output records
-  `emptyCompletion`.
+  `status: 502` plus an `emptyCompletion` marker: the client-visible
+  outcome is a `response.error` (empty_completion), never a successful
+  turn.
 - Retries are recorded only when there were any; a transparently absorbed
   upstream failure still records its real status.
 - Metering must never break a live request: every I/O error is swallowed.
@@ -24,6 +26,7 @@ import json
 import math
 import os
 import threading
+from dataclasses import dataclass, field
 from typing import Any
 
 Json = dict[str, Any]
@@ -50,6 +53,34 @@ DEFAULT_ESTIMATE_CONTEXT_WINDOW = 272000
 _lock = threading.Lock()
 
 _models_with_real_tokens: set[str] = set()
+
+# In-process fold of usage-events.jsonl: the aggregate is updated on every
+# append (under _lock) and served when the file identity is unchanged, so
+# /state never rescans the whole meter file. The fold covers exactly the
+# bytes [0, offset) of the file it was built from, keyed by a stat
+# fingerprint so a shrink or an in-place rewrite forces a full rescan.
+_FOLD_MARKER_BYTES = 256
+
+
+@dataclass
+class _Aggregate:
+    """Folded counts for one provider bucket (key None = all providers)."""
+    by_day_tokens: dict[str, int] = field(default_factory=dict)
+    by_day_turns: dict[str, int] = field(default_factory=dict)
+    last_model: str | None = None
+
+
+@dataclass
+class _Fold:
+    """The folded state plus the exact file identity it was folded from."""
+    fingerprint: tuple[int, int, int, int]  # (st_dev, st_ino, st_size, st_mtime_ns)
+    offset: int  # byte offset (EOF at fold time) the fold covers
+    bucketing_tz: datetime.tzinfo | None  # day-bucketing timezone the fold used
+    marker: bytes  # last bytes of the file at fold time; verifies appends
+    aggregates: dict[str | None, _Aggregate] = field(default_factory=dict)
+
+
+_fold: _Fold | None = None
 
 
 def state_dir() -> str:
@@ -159,6 +190,155 @@ def _local_day(value: Any, now: datetime.datetime) -> str | None:
     return instant.astimezone(now.tzinfo).date().isoformat()
 
 
+def _fingerprint(stat: os.stat_result) -> tuple[int, int, int, int]:
+    """File identity the fold is valid for: inode, size, and mtime."""
+    return (stat.st_dev, stat.st_ino, stat.st_size, stat.st_mtime_ns)
+
+
+def _same_bucketing_tz(a: datetime.tzinfo | None, b: datetime.tzinfo | None) -> bool:
+    """Whether two tzinfo objects bucket events into the same local days."""
+    if a is None or b is None:
+        return a is None and b is None
+    return a == b
+
+
+def _tail_bytes(path: str) -> bytes:
+    """Last ``_FOLD_MARKER_BYTES`` bytes of a file (the append-verification marker)."""
+    with open(path, "rb") as handle:
+        handle.seek(0, os.SEEK_END)
+        end = handle.tell()
+        handle.seek(max(0, end - _FOLD_MARKER_BYTES))
+        return handle.read()
+
+
+def _zero_summary(days: list[str]) -> Json:
+    """The degraded zeroed summary for an absent or unreadable meter file."""
+    return {
+        "todayTurns": 0,
+        "todayTokens": 0,
+        "last7d": [{"date": day, "tokens": 0} for day in days],
+        "model": None,
+    }
+
+
+def _fold_event(
+    aggregates: dict[str | None, _Aggregate],
+    event: Json,
+    now: datetime.datetime,
+) -> None:
+    """Fold one parsed event into the all-provider and its own provider bucket.
+
+    Mirrors the scan's exact bucketing rules: an event whose ``at`` does not
+    parse into a day is skipped entirely (no turns, tokens, or model), and
+    ``model`` is the most recent matching event's model.
+    """
+    day = _local_day(event.get("at"), now)
+    if day is None:
+        return
+    tokens = _event_tokens(event)
+    provider = event.get("provider")
+    keys: tuple[str | None, ...] = (None, provider) if isinstance(provider, str) and provider else (None,)
+    for key in keys:
+        agg = aggregates.get(key)
+        if agg is None:
+            agg = aggregates[key] = _Aggregate()
+        agg.by_day_tokens[day] = agg.by_day_tokens.get(day, 0) + tokens
+        agg.by_day_turns[day] = agg.by_day_turns.get(day, 0) + 1
+    model = event.get("model")
+    if isinstance(model, str) and model:
+        for key in keys:
+            aggregates[key].last_model = model
+
+
+def _summary_from(
+    aggregates: dict[str | None, _Aggregate],
+    provider: str | None,
+    now: datetime.datetime,
+    days: list[str],
+) -> Json:
+    """Render one provider's folded counts into the summary contract shape."""
+    agg = aggregates.get(provider)
+    if agg is None:
+        return _zero_summary(days)
+    today = now.date().isoformat()
+    return {
+        "todayTurns": agg.by_day_turns.get(today, 0),
+        "todayTokens": agg.by_day_tokens.get(today, 0),
+        "last7d": [{"date": day, "tokens": agg.by_day_tokens.get(day, 0)} for day in days],
+        "model": agg.last_model,
+    }
+
+
+def _scan_all(now: datetime.datetime) -> dict[str | None, _Aggregate]:
+    """Full rescan of the meter file, rebuilding the fold from scratch.
+
+    Raises OSError on I/O failure; the caller degrades to a zeroed summary.
+    """
+    global _fold
+    path = usage_events_path()
+    aggregates: dict[str | None, _Aggregate] = {}
+    with open(path, "rb") as handle:
+        for raw in handle:
+            if not raw.strip():
+                continue
+            try:
+                event = json.loads(raw)
+            except ValueError:
+                continue
+            if not isinstance(event, dict):
+                continue
+            _fold_event(aggregates, event, now)
+        offset = handle.tell()
+    stat = os.stat(path)
+    _fold = _Fold(
+        fingerprint=(stat.st_dev, stat.st_ino, offset, stat.st_mtime_ns),
+        offset=offset,
+        bucketing_tz=now.tzinfo,
+        marker=_tail_bytes(path),
+        aggregates=aggregates,
+    )
+    return aggregates
+
+
+def _fold_tail(now: datetime.datetime) -> dict[str | None, _Aggregate]:
+    """Fold only the bytes appended after the stored offset into the fold.
+
+    An append preserves the bytes before the old EOF, so the stored marker is
+    re-read at the boundary: a mismatch means the tail segment was rewritten,
+    and the whole file must be rescanned. Raises OSError on I/O failure.
+    """
+    path = usage_events_path()
+    with open(path, "rb") as handle:
+        handle.seek(_fold.offset)
+        tail = handle.read()
+        offset = _fold.offset + len(tail)
+    if not tail:
+        # The file shrank between stat and read; a rescan is the safe answer.
+        return _scan_all(now)
+    if _fold.marker:
+        with open(path, "rb") as handle:
+            handle.seek(_fold.offset - len(_fold.marker))
+            boundary = handle.read(len(_fold.marker))
+        if boundary != _fold.marker:
+            return _scan_all(now)
+    for raw in tail.splitlines():
+        if not raw.strip():
+            continue
+        try:
+            event = json.loads(raw)
+        except ValueError:
+            continue
+        if not isinstance(event, dict):
+            continue
+        _fold_event(_fold.aggregates, event, now)
+    stat = os.stat(path)
+    _fold.fingerprint = (stat.st_dev, stat.st_ino, offset, stat.st_mtime_ns)
+    _fold.offset = offset
+    _fold.bucketing_tz = now.tzinfo
+    _fold.marker = _tail_bytes(path)
+    return _fold.aggregates
+
+
 def usage_summary(now: datetime.datetime | None = None, provider: str | None = None) -> Json:
     """Aggregate meter events: today's turns/tokens, 7-day bars, last model.
 
@@ -169,53 +349,49 @@ def usage_summary(now: datetime.datetime | None = None, provider: str | None = N
     most recent event, or None when the meter file is absent or empty. When
     ``provider`` is given, only events whose ``provider`` field matches are
     counted (the zen rollup filters on provider="zen").
+
+    Reads are O(1) once the meter file has been folded: a stat fingerprint
+    (inode, size, mtime) decides between the cached aggregate, a tail fold of
+    appended bytes, and a full rescan when the file shrank or was replaced.
+    The fold is updated inside ``record_usage_event`` and guarded by the
+    module lock, so concurrent HTTP handlers never observe torn state.
     """
+    global _fold
     now = now or datetime.datetime.now().astimezone()
-    today = now.date().isoformat()
     days = [(now - datetime.timedelta(days=offset)).date().isoformat() for offset in range(6, -1, -1)]
-    by_day: dict[str, int] = {day: 0 for day in days}
-    today_turns = 0
-    today_tokens = 0
-    last_model: str | None = None
-    try:
-        with open(usage_events_path(), encoding="utf-8") as handle:
-            for line in handle:
-                if not line.strip():
-                    continue
+    with _lock:
+        try:
+            stat = os.stat(usage_events_path())
+        except OSError:
+            # Meter file absent or unreadable: degrade to zeros, never fail the endpoint.
+            _fold = None
+            return _zero_summary(days)
+        aggregates: dict[str | None, _Aggregate] | None
+        if _fold is not None and _same_bucketing_tz(_fold.bucketing_tz, now.tzinfo):
+            if _fingerprint(stat) == _fold.fingerprint:
+                aggregates = _fold.aggregates
+            elif (stat.st_dev, stat.st_ino) == (_fold.fingerprint[0], _fold.fingerprint[1]) and stat.st_size > _fold.offset:
                 try:
-                    event = json.loads(line)
-                except ValueError:
-                    continue
-                if not isinstance(event, dict):
-                    continue
-                if provider is not None and event.get("provider") != provider:
-                    continue
-                day = _local_day(event.get("at"), now)
-                if day is None:
-                    continue
-                tokens = _event_tokens(event)
-                if day in by_day:
-                    by_day[day] += tokens
-                    if day == today:
-                        today_turns += 1
-                        today_tokens += tokens
-                model = event.get("model")
-                if isinstance(model, str) and model:
-                    last_model = model
-    except OSError:
-        # Meter file absent or unreadable: degrade to zeros, never fail the endpoint.
-        return {
-            "todayTurns": 0,
-            "todayTokens": 0,
-            "last7d": [{"date": day, "tokens": 0} for day in days],
-            "model": None,
-        }
-    return {
-        "todayTurns": today_turns,
-        "todayTokens": today_tokens,
-        "last7d": [{"date": day, "tokens": by_day[day]} for day in days],
-        "model": last_model,
-    }
+                    aggregates = _fold_tail(now)
+                except OSError:
+                    _fold = None
+                    aggregates = None
+            else:
+                try:
+                    aggregates = _scan_all(now)
+                except OSError:
+                    _fold = None
+                    aggregates = None
+        else:
+            # No fold yet, a different bucketing tz, or a replaced file: rescan.
+            try:
+                aggregates = _scan_all(now)
+            except OSError:
+                _fold = None
+                aggregates = None
+        if aggregates is None:
+            return _zero_summary(days)
+        return _summary_from(aggregates, provider, now, days)
 
 
 def record_usage_event(
@@ -282,6 +458,29 @@ def record_usage_event(
             with open(path, "a", encoding="utf-8") as handle:
                 handle.write(line + "\n")
                 handle.flush()
+                end = handle.tell()
+                file_stat = os.fstat(handle.fileno())
         except OSError:
             # Metering is best-effort; never break a live request over it.
-            pass
+            return
+        if _fold is not None and (file_stat.st_dev, file_stat.st_ino) == (
+            _fold.fingerprint[0], _fold.fingerprint[1]
+        ):
+            # The fold must be the one built from THIS file (a stale fold from
+            # a previous state dir is discarded by the next summary's rescan),
+            # and our line must start exactly at the fold's EOF: anything else
+            # means bytes we never folded slipped in, so the fold is left as-is
+            # and the next summary's tail fold or rescan picks them up.
+            line_bytes = len(line.encode("utf-8")) + 1
+            if end - line_bytes == _fold.offset:
+                try:
+                    # Fold the appended event so the next summary is O(1). Day
+                    # buckets use the fold's own tz; a summary in a different
+                    # tz rescans and re-keys the fold.
+                    _fold_event(_fold.aggregates, record, datetime.datetime.now(_fold.bucketing_tz))
+                    _fold.fingerprint = (file_stat.st_dev, file_stat.st_ino, end, file_stat.st_mtime_ns)
+                    _fold.offset = end
+                    _fold.marker = _tail_bytes(path)
+                except OSError:
+                    # The fold is best-effort too; the next summary recovers it.
+                    return

--- a/src/opencode_go_proxy/protocol.py
+++ b/src/opencode_go_proxy/protocol.py
@@ -146,7 +146,45 @@ def _catalog_mtime() -> tuple[str, int | None]:
         return path, None
 
 
-_KNOWN_MODELS_CACHE: tuple[str, int | None, set[str]] | None = None
+# One mtime-keyed parse serves all three catalog views below: known slugs,
+# context windows, and image-capable slugs. The full-shape catalog file is
+# only read once per change instead of once per view.
+_CATALOG_CACHE: tuple[str, int | None, set[str], dict[str, int], set[str]] | None = None
+
+
+def _catalog_views() -> tuple[str, int | None, set[str], dict[str, int], set[str]]:
+    """Parse the catalog once, cached by file mtime; (path, mtime, slugs, windows, image_slugs)."""
+    global _CATALOG_CACHE
+
+    path, mtime = _catalog_mtime()
+    if (
+        _CATALOG_CACHE is not None
+        and _CATALOG_CACHE[0] == path
+        and _CATALOG_CACHE[1] == mtime
+    ):
+        return _CATALOG_CACHE
+    slugs: set[str] = set()
+    windows: dict[str, int] = {}
+    image_slugs: set[str] = set()
+    try:
+        with open(path) as handle:
+            catalog = json.load(handle)
+        for entry in catalog.get("models", []):
+            if not isinstance(entry, dict):
+                continue
+            slug = entry.get("slug")
+            if isinstance(slug, str) and slug:
+                slugs.add(slug)
+                context = entry.get("context_window")
+                if isinstance(context, int) and context > 0:
+                    windows[slug] = context
+                modalities = entry.get("input_modalities")
+                if isinstance(modalities, list) and "image" in modalities:
+                    image_slugs.add(slug)
+    except (OSError, json.JSONDecodeError):
+        pass
+    _CATALOG_CACHE = (path, mtime, slugs, windows, image_slugs)
+    return _CATALOG_CACHE
 
 
 def known_models() -> set[str]:
@@ -156,31 +194,14 @@ def known_models() -> set[str]:
     makes the next call re-read without a restart. reload_known_models()
     bypasses the cache explicitly.
     """
-    global _KNOWN_MODELS_CACHE
-    from opencode_go_proxy import catalog as _catalog
-
-    path, mtime = _catalog_mtime()
-    if (
-        _KNOWN_MODELS_CACHE is not None
-        and _KNOWN_MODELS_CACHE[0] == path
-        and _KNOWN_MODELS_CACHE[1] == mtime
-    ):
-        return _KNOWN_MODELS_CACHE[2]
-    slugs = _catalog.load_known_slugs(catalog_path=path)
-    _KNOWN_MODELS_CACHE = (path, mtime, slugs)
-    return slugs
+    return _catalog_views()[2]
 
 
 def reload_known_models() -> set[str]:
-    """Drop the mtime caches and re-read known slugs from the catalog."""
-    global _KNOWN_MODELS_CACHE, _IMAGE_CAPABLE_CACHE, _CONTEXT_WINDOW_CACHE
-    _KNOWN_MODELS_CACHE = None
-    _IMAGE_CAPABLE_CACHE = None
-    _CONTEXT_WINDOW_CACHE = None
+    """Drop the mtime cache and re-read known slugs from the catalog."""
+    global _CATALOG_CACHE
+    _CATALOG_CACHE = None
     return known_models()
-
-
-_CONTEXT_WINDOW_CACHE: tuple[str, int | None, dict[str, int]] | None = None
 
 
 def model_context_window(model: str) -> int | None:
@@ -190,34 +211,7 @@ def model_context_window(model: str) -> int | None:
     file mtime. Used to cap zero-input-token estimates at the model's real
     window instead of a proxy-wide default.
     """
-    global _CONTEXT_WINDOW_CACHE
-
-    path, mtime = _catalog_mtime()
-    if (
-        _CONTEXT_WINDOW_CACHE is not None
-        and _CONTEXT_WINDOW_CACHE[0] == path
-        and _CONTEXT_WINDOW_CACHE[1] == mtime
-    ):
-        windows = _CONTEXT_WINDOW_CACHE[2]
-    else:
-        windows = {}
-        try:
-            with open(path) as f:
-                catalog = json.load(f)
-            for entry in catalog.get("models", []):
-                if not isinstance(entry, dict):
-                    continue
-                slug = entry.get("slug")
-                context = entry.get("context_window")
-                if isinstance(slug, str) and slug and isinstance(context, int) and context > 0:
-                    windows[slug] = context
-        except (OSError, json.JSONDecodeError):
-            pass
-        _CONTEXT_WINDOW_CACHE = (path, mtime, windows)
-    return windows.get(model)
-
-
-_IMAGE_CAPABLE_CACHE: tuple[str, int | None, set[str]] | None = None
+    return _catalog_views()[3].get(model)
 
 
 def image_capable_models() -> set[str]:
@@ -227,35 +221,7 @@ def image_capable_models() -> set[str]:
     re-read. Used to keep image turns on the requested model when it can
     actually accept images, instead of always forcing the image default.
     """
-    global _IMAGE_CAPABLE_CACHE
-
-    path, mtime = _catalog_mtime()
-    if (
-        _IMAGE_CAPABLE_CACHE is not None
-        and _IMAGE_CAPABLE_CACHE[0] == path
-        and _IMAGE_CAPABLE_CACHE[1] == mtime
-    ):
-        return _IMAGE_CAPABLE_CACHE[2]
-    slugs: set[str] = set()
-    try:
-        with open(path) as f:
-            catalog = json.load(f)
-        for entry in catalog.get("models", []):
-            if not isinstance(entry, dict):
-                continue
-            slug = entry.get("slug")
-            modalities = entry.get("input_modalities")
-            if (
-                isinstance(slug, str)
-                and slug
-                and isinstance(modalities, list)
-                and "image" in modalities
-            ):
-                slugs.add(slug)
-    except (OSError, json.JSONDecodeError):
-        pass
-    _IMAGE_CAPABLE_CACHE = (path, mtime, slugs)
-    return slugs
+    return _catalog_views()[4]
 
 
 def new_response_id() -> str:

--- a/src/opencode_go_proxy/quota.py
+++ b/src/opencode_go_proxy/quota.py
@@ -47,6 +47,20 @@ _ANTHROPIC_FAMILIES = (
 
 _lock = threading.Lock()
 
+# Quota harvesting is throttled: identical snapshots are skipped entirely and
+# distinct snapshots are persisted at most once per second, so a burst of 200
+# responses with ratelimit headers costs one fsync+atomic-replace, not one
+# per request.
+WRITE_INTERVAL_SECONDS = 1.0
+
+# (path, monotonic write time) of the last persisted write; keyed by path so
+# a fresh state dir is never throttled by a previous dir's writes.
+_last_write: tuple[str, float] | None = None
+
+# (stat fingerprint, parsed state) memo for read_quota_state; callers never
+# mutate the returned value, so the cached object is safe to share.
+_read_cache: tuple[tuple[int, int, int, int], Json] | None = None
+
 
 def quota_state_path() -> str:
     return os.path.join(state_dir(), "quota-state.json")
@@ -174,14 +188,31 @@ def quota_snapshot_from_headers(headers: Any) -> dict[str, Json]:
 
 
 def read_quota_state() -> Json:
-    """Read quota-state.json; an absent or corrupt file yields an empty state."""
+    """Read quota-state.json; an absent or corrupt file yields an empty state.
+
+    The parse is memoized on the file's stat fingerprint (inode, size, mtime),
+    so /state's per-poll read is O(1) while the file is unchanged; any write,
+    replace, or external edit invalidates it. Callers must treat the returned
+    dict as read-only.
+    """
+    global _read_cache
+    path = quota_state_path()
     try:
-        with open(quota_state_path(), encoding="utf-8") as handle:
+        stat = os.stat(path)
+    except OSError:
+        return {"providers": {}}
+    fingerprint = (stat.st_dev, stat.st_ino, stat.st_size, stat.st_mtime_ns)
+    if _read_cache is not None and _read_cache[0] == fingerprint:
+        return _read_cache[1]
+    try:
+        with open(path, encoding="utf-8") as handle:
             value = json.load(handle)
         if isinstance(value, dict) and isinstance(value.get("providers"), dict):
+            _read_cache = (fingerprint, value)
             return value
     except (OSError, ValueError):
         pass
+    _read_cache = (fingerprint, {"providers": {}})
     return {"providers": {}}
 
 
@@ -197,15 +228,34 @@ def _write_state(state: Json) -> None:
 
 
 def record_quota_from_headers(headers: Any) -> None:
-    """Parse response headers and persist the latest snapshot per provider."""
+    """Parse response headers and persist the latest snapshot per provider.
+
+    The write is skipped when the merged snapshot equals the persisted state
+    (field-wise, including sampledAt) and throttled to at most one write per
+    ``WRITE_INTERVAL_SECONDS`` per state file, so header-rich 200s don't
+    fsync+atomic-replace on every request.
+    """
     snapshots = quota_snapshot_from_headers(headers)
     if not snapshots:
         return
+    global _last_write
     with _lock:
         try:
             state = read_quota_state()
-            state["providers"].update(snapshots)
-            _write_state(state)
+            merged = dict(state)
+            merged["providers"] = dict(state.get("providers", {}))
+            merged["providers"].update(snapshots)
+            if merged == state:
+                return
+            path = quota_state_path()
+            now = time.monotonic()
+            same_file_as_last_write = (
+                _last_write is not None and _last_write[0] == path
+            )
+            if same_file_as_last_write and now - _last_write[1] < WRITE_INTERVAL_SECONDS:
+                return
+            _write_state(merged)
+            _last_write = (path, time.monotonic())
         except OSError:
             # Quota harvesting is best-effort; never break a live request.
             pass

--- a/src/opencode_go_proxy/routing.py
+++ b/src/opencode_go_proxy/routing.py
@@ -1,10 +1,13 @@
-"""Model routing: native Codex models vs the OpenCode Go translation path.
+"""Model routing: native Codex models vs the OpenCode Go and Zen translation paths.
 
 Native membership comes from the state-dir native-models.json snapshot
-(native_models.capture_native_models); every other slug routes to the
-opencode-go translation path. An explicit ``opencode-go/<slug>`` prefix
-always wins, even when the bare slug matches a native model: the user chose
-the routed provider, and that request must never reach the native backend.
+(native_models.capture_native_models); every other slug routes to a
+translation path. An explicit ``opencode-go/<slug>`` or ``zen/<slug>`` prefix
+always wins over native membership: the user chose the routed provider, and
+that request must never reach the native backend. Bare slugs are never zen —
+zen models are only reachable with the ``zen/`` prefix, so a bare
+deepseek-v4-flash stays on the opencode-go path even though zen serves the
+same id.
 """
 
 from __future__ import annotations
@@ -13,16 +16,19 @@ import os
 from typing import Literal
 
 from .native_models import load_native_capture, native_models_path, native_slugs
+from .zen_catalog import ZEN_PREFIX
 
-RouteTarget = Literal["native", "opencode_go"]
+RouteTarget = Literal["native", "opencode_go", "zen"]
 
 OPENCODE_GO_PREFIX = "opencode-go/"
 
 
 def normalize_model_slug(slug: str) -> str:
-    """Strip the ``opencode-go/`` provider prefix; any other slug is unchanged."""
+    """Strip the ``opencode-go/`` or ``zen/`` provider prefix; any other slug is unchanged."""
     if slug.startswith(OPENCODE_GO_PREFIX):
         return slug[len(OPENCODE_GO_PREFIX):]
+    if slug.startswith(ZEN_PREFIX):
+        return slug[len(ZEN_PREFIX):]
     return slug
 
 
@@ -55,9 +61,16 @@ def native_model_slugs() -> set[str]:
 
 
 def route_target(slug: str, native_slugs: set[str] | None = None) -> RouteTarget:
-    """Prefixed slugs are always opencode_go; bare slugs test native membership."""
+    """Prefix order: ``opencode-go/`` then ``zen/``; bare slugs test native membership.
+
+    Bare slugs never route zen: a zen model must be addressed with its
+    ``zen/`` prefix, and an unprefixed slug that happens to share a zen id
+    stays on the opencode-go path.
+    """
     if slug.startswith(OPENCODE_GO_PREFIX):
         return "opencode_go"
+    if slug.startswith(ZEN_PREFIX):
+        return "zen"
     if native_slugs is None:
         native_slugs = native_model_slugs()
     return "native" if slug in native_slugs else "opencode_go"

--- a/src/opencode_go_proxy/state.py
+++ b/src/opencode_go_proxy/state.py
@@ -2,25 +2,31 @@
 
 Composes the proxy's local state into one JSON document for the macOS menu
 bar: server identity (status/port/upstream), the latest quota snapshot, usage
-aggregates from the meter file, and the current model. Everything is
-best-effort: a missing or corrupt meter or quota file degrades to zeros or
-null rather than failing the endpoint, so the menu bar always gets a stable
-shape to render.
+aggregates from the meter file, the polled OpenCode Go plan usage, and the
+current model. Everything is best-effort: a missing or corrupt meter or quota
+file, or an unreachable usage endpoint, degrades to zeros or null rather than
+failing the endpoint, so the menu bar always gets a stable shape to render.
 """
 
 from __future__ import annotations
 
 import datetime
-import json
 from typing import Any
 
-from .meter import usage_events_path
+from .meter import usage_summary
 from .protocol import DEFAULT_MODEL
 from .quota import read_quota_state
+from .usage_poller import poll_go_usage
 
 Json = dict[str, Any]
 
-_DAY_KEYS = ("inputTokens", "outputTokens")
+# Dollar budgets for the OpenCode Go plan, rendered next to live usage.
+GO_LIMITS: Json = {
+    "monthlyDollars": 60,
+    "weeklyDollars": 30,
+    "rolling5hDollars": 12,
+    "subscriptionMonthlyDollars": 10,
+}
 
 
 def _clean_int(value: Any) -> int | None:
@@ -32,83 +38,6 @@ def _clean_int(value: Any) -> int | None:
     if isinstance(value, float) and value.is_integer() and value >= 0:
         return int(value)
     return None
-
-
-def _event_tokens(event: Json) -> int:
-    """Tokens for one event: totalTokens, or the zero-token estimate when the
-    upstream reported 0 (estimatedInputTokens plus any real output)."""
-    total = _clean_int(event.get("totalTokens"))
-    if total is not None and total > 0:
-        return total
-    estimated = _clean_int(event.get("estimatedInputTokens"))
-    if estimated is not None and estimated > 0:
-        output = _clean_int(event.get("outputTokens")) or 0
-        return estimated + output
-    if total is not None:
-        return total
-    return sum(_clean_int(event.get(key)) or 0 for key in _DAY_KEYS)
-
-
-def _local_day(value: Any, now: datetime.datetime) -> str | None:
-    """ISO day string (YYYY-MM-DD) in ``now``'s timezone for an event ``at``."""
-    if not isinstance(value, str):
-        return None
-    try:
-        instant = datetime.datetime.fromisoformat(value)
-    except ValueError:
-        return None
-    if instant.tzinfo is None:
-        instant = instant.replace(tzinfo=datetime.UTC)
-    return instant.astimezone(now.tzinfo).date().isoformat()
-
-
-def usage_summary(now: datetime.datetime | None = None) -> Json:
-    """Aggregate meter events: today's turns/tokens, 7-day bars, last model.
-
-    Days are bucketed in the caller's local timezone so the menu bar's
-    "today" matches the calendar day the user sees. ``last7d`` is always
-    seven entries (oldest first, including today), zero-filled for quiet
-    days, so the UI renders a stable bar list. ``model`` is the model of the
-    most recent event, or None when the meter file is absent or empty.
-    """
-    now = now or datetime.datetime.now().astimezone()
-    today = now.date().isoformat()
-    days = [(now - datetime.timedelta(days=offset)).date().isoformat() for offset in range(6, -1, -1)]
-    by_day: dict[str, int] = {day: 0 for day in days}
-    today_turns = 0
-    today_tokens = 0
-    last_model: str | None = None
-    try:
-        with open(usage_events_path(), encoding="utf-8") as handle:
-            for line in handle:
-                if not line.strip():
-                    continue
-                try:
-                    event = json.loads(line)
-                except ValueError:
-                    continue
-                if not isinstance(event, dict):
-                    continue
-                day = _local_day(event.get("at"), now)
-                if day is None:
-                    continue
-                tokens = _event_tokens(event)
-                if day in by_day:
-                    by_day[day] += tokens
-                    if day == today:
-                        today_turns += 1
-                        today_tokens += tokens
-                model = event.get("model")
-                if isinstance(model, str) and model:
-                    last_model = model
-    except OSError:
-        pass
-    return {
-        "todayTurns": today_turns,
-        "todayTokens": today_tokens,
-        "last7d": [{"date": day, "tokens": by_day[day]} for day in days],
-        "model": last_model,
-    }
 
 
 def _sampled_at(value: Any) -> float | None:
@@ -156,8 +85,23 @@ def _latest_quota() -> Json | None:
     return best
 
 
+def _zen_rollup(now: datetime.datetime | None = None) -> Json:
+    """Zen-only usage: today's turns/tokens and seven daily token sums."""
+    summary = usage_summary(now, provider="zen")
+    return {
+        "todayTurns": summary["todayTurns"],
+        "todayTokens": summary["todayTokens"],
+        "last7d": [day["tokens"] for day in summary["last7d"]],
+    }
+
+
 def build_state(port: int, upstream: str, now: datetime.datetime | None = None) -> Json:
-    """One stable JSON contract for the menu bar (GET /state)."""
+    """One stable JSON contract for the menu bar (GET /state).
+
+    ``usage`` keeps the legacy all-provider keys (todayTurns, todayTokens,
+    last7d) and adds the Go plan slot (null when the poller cannot fetch it),
+    the fixed Go dollar budgets, and the zen-only rollup.
+    """
     usage = usage_summary(now)
     model = usage.get("model")
     if not isinstance(model, str) or not model:
@@ -167,6 +111,13 @@ def build_state(port: int, upstream: str, now: datetime.datetime | None = None) 
         "port": int(port),
         "upstream": upstream,
         "quota": _latest_quota(),
-        "usage": {key: usage[key] for key in ("todayTurns", "todayTokens", "last7d")},
+        "usage": {
+            "todayTurns": usage["todayTurns"],
+            "todayTokens": usage["todayTokens"],
+            "last7d": usage["last7d"],
+            "go": poll_go_usage(),
+            "goLimits": dict(GO_LIMITS),
+            "zen": _zen_rollup(now),
+        },
         "model": model,
     }

--- a/src/opencode_go_proxy/streaming.py
+++ b/src/opencode_go_proxy/streaming.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import http.client
 import json
 import os
+import socket
 import threading
 import time
 import urllib.error
@@ -61,6 +62,47 @@ def keepalive_sec() -> float:
         return max(0.05, float(os.environ.get("OPENCODE_GO_PROXY_KEEPALIVE_SEC", str(DEFAULT_KEEPALIVE_SEC))))
     except ValueError:
         return DEFAULT_KEEPALIVE_SEC
+
+
+def _client_gone(wfile: Any) -> bool:
+    """Peek the client socket to detect a peer that closed its read side.
+
+    On macOS a write to a reset peer does not error, so a cancelling client is
+    invisible to write-failure detection and the turn would meter as a full
+    stream. A non-blocking MSG_PEEK recv observes the peer state directly:
+    EOF (b'') when the client closed, an error when it reset. The peek is
+    best-effort: any unexpected failure degrades to "alive" so a liveness
+    probe can never break a live stream.
+    """
+    try:
+        sock = getattr(wfile, "_sock", None)
+        if sock is None:
+            # A buffered wfile (makefile with default buffering) hides the
+            # socket behind .raw; the real handler uses the unbuffered form.
+            sock = getattr(getattr(wfile, "raw", None), "_sock", None)
+        if sock is None:
+            return False
+        was_blocking = sock.getblocking()
+        sock.setblocking(False)
+        try:
+            try:
+                data = sock.recv(1, socket.MSG_PEEK)
+            except (AttributeError, NotImplementedError):
+                # Platform without MSG_PEEK: a plain recv still observes EOF.
+                data = sock.recv(1)
+            except BlockingIOError:
+                return False  # alive: no pending data, connection open
+            except (ConnectionResetError, ConnectionAbortedError, OSError):
+                return True  # peer reset its connection
+            return data == b""  # EOF: peer closed its read side
+        finally:
+            # Restore blocking mode; a concurrent close makes the restore
+            # itself fail, which the outer guard degrades to "alive".
+            sock.setblocking(was_blocking)
+    except (AttributeError, OSError, ValueError):
+        # No peekable socket (test doubles, already closed, unsupported
+        # flags): fall back to the old write-only detection.
+        return False
 
 
 class _ConnectFailed(Exception):
@@ -136,6 +178,12 @@ def handle_streaming_request(payload: Json, config: ProxyConfig, request_id: str
     write_lock = threading.Lock()
 
     def _write(data: bytes) -> bool:
+        # Liveness peek before every write (keepalive comments and data
+        # frames): on macOS writes to a reset peer do not error, so without
+        # the peek a cancelling client would be invisible until the stream
+        # ends and the turn would meter as a full 200.
+        if _client_gone(wfile):
+            return False
         try:
             with write_lock:
                 wfile.write(data)
@@ -488,7 +536,9 @@ def handle_streaming_request(payload: Json, config: ProxyConfig, request_id: str
                 if isinstance(inp, int) and inp > 0:
                     note_real_input_tokens(model)
                 estimated = estimate_input_tokens(model, len(raw_payload), usage, context_window=context_cap)
-                record_usage_event(model=model, status=200, duration_ms=duration_ms,
+                # The client-visible outcome is response.error empty_completion,
+                # so the meter records 502 (a failed turn), never a success.
+                record_usage_event(model=model, status=502, duration_ms=duration_ms,
                                    input_tokens=inp, output_tokens=outp, total_tokens=total,
                                    estimated_input_tokens=estimated,
                                    empty_completion=True, retries=total_retries + 1 + fallback_attempts)
@@ -619,8 +669,11 @@ def handle_chat_stream_passthrough(payload: Json, config: ProxyConfig, request_i
             # status and error body, not a proxy envelope.
             body = fail.body
             content_type = (exc.headers.get("content-type") if exc.headers else None) or "application/json"
+            retry_after = (exc.headers or {}).get("retry-after")
             handler.send_response(exc.code)
             handler.send_header("content-type", content_type)
+            if retry_after:
+                handler.send_header("retry-after", retry_after)
             handler.send_header("content-length", str(len(body)))
             handler.end_headers()
             handler.wfile.write(body)
@@ -654,6 +707,9 @@ def handle_chat_stream_passthrough(payload: Json, config: ProxyConfig, request_i
         while not keepalive_stop.wait(interval):
             if not client_alive:
                 return
+            if _client_gone(handler.wfile):
+                client_alive = False
+                return
             try:
                 with write_lock:
                     handler.wfile.write(b": keepalive\n\n")
@@ -669,6 +725,14 @@ def handle_chat_stream_passthrough(payload: Json, config: ProxyConfig, request_i
         with response as resp:
             for line in resp:
                 if not client_alive:
+                    break
+                # Liveness peek before each relayed frame: on macOS a write to
+                # a reset peer does not error, so the peek is what makes a
+                # cancelling client visible instead of metering a full 200.
+                if _client_gone(handler.wfile):
+                    client_alive = False
+                    trace("client.disconnected", request_id=request_id,
+                          message="client closed connection during stream")
                     break
                 try:
                     with write_lock:
@@ -690,7 +754,15 @@ def handle_chat_stream_passthrough(payload: Json, config: ProxyConfig, request_i
 
     elapsed_ms = int((time.time() - started) * 1000)
     trace("upstream.done", request_id=request_id, status=response.status, elapsed_ms=elapsed_ms, stream=True)
-    record_usage_event(
-        model=payload.get("model") or DEFAULT_MODEL, status=response.status,
-        duration_ms=elapsed_ms, retries=retries or None,
-    )
+    if not client_alive:
+        # The client cancelled before the relay finished; the upstream's 200 is
+        # not a success the client ever received, so meter the abort.
+        record_usage_event(
+            model=payload.get("model") or DEFAULT_MODEL, status=0,
+            duration_ms=elapsed_ms, stream_aborted=True, retries=retries or None,
+        )
+    else:
+        record_usage_event(
+            model=payload.get("model") or DEFAULT_MODEL, status=response.status,
+            duration_ms=elapsed_ms, retries=retries or None,
+        )

--- a/src/opencode_go_proxy/upstream.py
+++ b/src/opencode_go_proxy/upstream.py
@@ -129,8 +129,14 @@ def call_upstream_chat(chat_payload: Json, config: ProxyConfig, request_id: str,
                 retry_sleep(retries)
                 continue
             if exc.code == 429:
-                retry_after = exc.headers.get("retry-after", "5")
-                raise ProxyError(HTTPStatus.TOO_MANY_REQUESTS, f"rate limited (retry after {retry_after}s)", retries=retries) from exc
+                upstream_retry_after = (exc.headers or {}).get("retry-after")
+                retry_after = upstream_retry_after or "5"
+                raise ProxyError(
+                    HTTPStatus.TOO_MANY_REQUESTS,
+                    f"rate limited (retry after {retry_after}s)",
+                    retries=retries,
+                    headers={"retry-after": upstream_retry_after} if upstream_retry_after else None,
+                ) from exc
             if exc.code == 503:
                 raise ProxyError(HTTPStatus.SERVICE_UNAVAILABLE, "upstream unavailable", retries=retries) from exc
             if exc.code == 504:
@@ -157,15 +163,17 @@ def call_upstream_chat(chat_payload: Json, config: ProxyConfig, request_id: str,
 def call_upstream_chat_verbatim(
     chat_payload: Json, config: ProxyConfig, request_id: str,
     *, timeout_sec: float | None = None, max_retries: int | None = None,
-) -> tuple[int, bytes, int, str | None]:
-    """POST chat/completions and return ``(status, raw_body, retries, content_type)``.
+) -> tuple[int, bytes, int, str | None, str | None]:
+    """POST chat/completions and return ``(status, raw_body, retries, content_type, retry_after)``.
 
     The /chat/completions passthrough relay: an upstream HTTP error is returned
     with the upstream's own status and body so the proxy relays it verbatim
     instead of substituting a ``proxy_error`` envelope. Transient failures
     (429 / 5xx) retry under the same policy as :func:`call_upstream_chat`;
     network and timeout failures have no upstream body to relay, so they still
-    raise :class:`ProxyError` like the JSON-mapping variant.
+    raise :class:`ProxyError` like the JSON-mapping variant. ``retry_after``
+    is the upstream's retry-after header value (lowercased lookup, None when
+    absent) so the relay can forward it on rate-limit responses.
     """
     api_key = resolve_api_key(config, request_id)
 
@@ -183,7 +191,7 @@ def call_upstream_chat_verbatim(
                 record_quota_from_headers(getattr(response, "headers", None))
                 elapsed_ms = int((time.time() - started) * 1000)
                 trace("upstream.done", request_id=request_id, status=response.status, bytes=len(body), elapsed_ms=elapsed_ms)
-                return response.status, body, retries, response.headers.get("content-type")
+                return response.status, body, retries, response.headers.get("content-type"), (response.headers or {}).get("retry-after")
         except urllib.error.HTTPError as exc:
             body = exc.read()
             trace("upstream.error", request_id=request_id, status=exc.code, body=_mask_trace_body(body.decode("utf-8", errors="replace")))
@@ -192,7 +200,7 @@ def call_upstream_chat_verbatim(
                 trace("upstream.retry", request_id=request_id, attempt=retries, status=exc.code)
                 retry_sleep(retries)
                 continue
-            return exc.code, body, retries, (exc.headers.get("content-type") if exc.headers else None)
+            return exc.code, body, retries, (exc.headers.get("content-type") if exc.headers else None), (exc.headers or {}).get("retry-after")
         except urllib.error.URLError as exc:
             trace("upstream.network_error", request_id=request_id, reason=str(getattr(exc, "reason", exc)))
             if retries < max_retries:

--- a/src/opencode_go_proxy/usage_poller.py
+++ b/src/opencode_go_proxy/usage_poller.py
@@ -1,0 +1,114 @@
+"""Poll the OpenCode Go plan usage endpoint for the menu bar.
+
+Fetches rolling/weekly/monthly usage from opencode.ai with the same API key
+the proxy uses for upstream traffic, cached in memory for a minute so /state
+never blocks on the network more than once a minute. Best-effort by
+contract: any failure (missing key, HTTP error, timeout, malformed body)
+returns None and never raises, so /state always keeps its stable shape.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+import urllib.request
+from typing import Any
+
+from .config import ProxyConfig, resolve_chat_base_url
+from .errors import ProxyError
+from .secrets import configured_key_env, resolve_api_key
+
+Json = dict[str, Any]
+
+USAGE_URL_ENV = "OPENCODE_GO_USAGE_URL"
+DEFAULT_USAGE_URL = "https://opencode.ai/zen/go/v1/usage"
+POLL_TIMEOUT_SEC = 5
+TTL_SECONDS = 60
+
+# Defaults mirrored from ops._proxy_config() for key resolution when no
+# caller supplies a config (the /state handler passes none today).
+DEFAULT_BIND = "127.0.0.1"
+DEFAULT_PORT = 8787
+DEFAULT_TIMEOUT_SEC = 180
+DEFAULT_MAX_BODY_BYTES = 20 * 1024 * 1024
+
+# Trace label for key resolution, distinct from request-scoped labels.
+_REQUEST_ID = "usage-poll"
+
+_lock = threading.Lock()
+# (monotonic fetch time, parsed usage dict); set only on successful fetches.
+_cache: tuple[float, Json] | None = None
+
+
+def usage_url() -> str:
+    """The usage endpoint the poller hits (env override for tests)."""
+    return os.environ.get(USAGE_URL_ENV) or DEFAULT_USAGE_URL
+
+
+def clear_cache() -> None:
+    """Drop the TTL cache (test isolation only)."""
+    global _cache
+    with _lock:
+        _cache = None
+
+
+def poll_go_usage(config: ProxyConfig | None = None) -> Json | None:
+    """Return OpenCode Go usage, fresh or from the TTL cache; None on failure.
+
+    The returned shape is {"rolling": {...}, "weekly": {...}, "monthly": {...}}.
+    Never raises: a missing key, HTTP error, timeout, or malformed body all
+    degrade to None so callers can render a null slot. With no config the
+    poller resolves the key with the proxy's default env (and keychain).
+    """
+    global _cache
+    now = time.monotonic()
+    with _lock:
+        cached = _cache
+    if cached is not None and now - cached[0] < TTL_SECONDS:
+        return cached[1]
+    usage = _fetch_usage(config if config is not None else _default_config())
+    if usage is not None:
+        with _lock:
+            _cache = (time.monotonic(), usage)
+    return usage
+
+
+def _default_config() -> ProxyConfig:
+    """A ProxyConfig for key resolution when the caller supplies none."""
+    return ProxyConfig(
+        bind=DEFAULT_BIND,
+        port=DEFAULT_PORT,
+        chat_base_url=resolve_chat_base_url(),
+        api_key_env=configured_key_env(),
+        timeout_sec=DEFAULT_TIMEOUT_SEC,
+        max_body_bytes=DEFAULT_MAX_BODY_BYTES,
+    )
+
+
+def _fetch_usage(config: ProxyConfig) -> Json | None:
+    """One uncached GET of the usage endpoint; None on any failure."""
+    try:
+        api_key = resolve_api_key(config, _REQUEST_ID)
+    except ProxyError:
+        # No resolvable key: usage is unknowable, degrade to null.
+        return None
+    request = urllib.request.Request(
+        usage_url(),
+        headers={"Authorization": f"Bearer {api_key}", "Accept": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=POLL_TIMEOUT_SEC) as response:
+            body = response.read()
+    except OSError:
+        # URLError (incl. HTTPError) and socket.timeout are OSError subclasses.
+        return None
+    try:
+        payload = json.loads(body)
+    except ValueError:
+        return None
+    usage = payload.get("usage") if isinstance(payload, dict) else None
+    if not isinstance(usage, dict):
+        return None
+    return usage

--- a/src/opencode_go_proxy/usage_poller.py
+++ b/src/opencode_go_proxy/usage_poller.py
@@ -26,6 +26,9 @@ USAGE_URL_ENV = "OPENCODE_GO_USAGE_URL"
 DEFAULT_USAGE_URL = "https://opencode.ai/zen/go/v1/usage"
 POLL_TIMEOUT_SEC = 5
 TTL_SECONDS = 60
+# A failed poll is also cached (short TTL) so a dead endpoint cannot stall
+# /state by re-fetching 2x5s on every poll.
+FAILURE_TTL_SECONDS = 15
 
 # Defaults mirrored from ops._proxy_config() for key resolution when no
 # caller supplies a config (the /state handler passes none today).
@@ -40,6 +43,9 @@ _REQUEST_ID = "usage-poll"
 _lock = threading.Lock()
 # (monotonic fetch time, parsed usage dict); set only on successful fetches.
 _cache: tuple[float, Json] | None = None
+# (monotonic failure time, None); set only on failed fetches so a dead
+# endpoint degrades to None without a network round-trip for 15s.
+_failure_cache: tuple[float, None] | None = None
 
 
 def usage_url() -> str:
@@ -48,10 +54,11 @@ def usage_url() -> str:
 
 
 def clear_cache() -> None:
-    """Drop the TTL cache (test isolation only)."""
-    global _cache
+    """Drop the TTL and failure caches (test isolation only)."""
+    global _cache, _failure_cache
     with _lock:
         _cache = None
+        _failure_cache = None
 
 
 def poll_go_usage(config: ProxyConfig | None = None) -> Json | None:
@@ -62,16 +69,23 @@ def poll_go_usage(config: ProxyConfig | None = None) -> Json | None:
     degrade to None so callers can render a null slot. With no config the
     poller resolves the key with the proxy's default env (and keychain).
     """
-    global _cache
+    global _cache, _failure_cache
     now = time.monotonic()
     with _lock:
         cached = _cache
+        failed = _failure_cache
     if cached is not None and now - cached[0] < TTL_SECONDS:
         return cached[1]
+    if failed is not None and now - failed[0] < FAILURE_TTL_SECONDS:
+        return None
     usage = _fetch_usage(config if config is not None else _default_config())
     if usage is not None:
         with _lock:
             _cache = (time.monotonic(), usage)
+            _failure_cache = None
+    else:
+        with _lock:
+            _failure_cache = (time.monotonic(), None)
     return usage
 
 

--- a/src/opencode_go_proxy/usage_poller.py
+++ b/src/opencode_go_proxy/usage_poller.py
@@ -94,15 +94,27 @@ def _fetch_usage(config: ProxyConfig) -> Json | None:
     except ProxyError:
         # No resolvable key: usage is unknowable, degrade to null.
         return None
-    request = urllib.request.Request(
-        usage_url(),
-        headers={"Authorization": f"Bearer {api_key}", "Accept": "application/json"},
-    )
-    try:
-        with urllib.request.urlopen(request, timeout=POLL_TIMEOUT_SEC) as response:
-            body = response.read()
-    except OSError:
-        # URLError (incl. HTTPError) and socket.timeout are OSError subclasses.
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Accept": "application/json",
+        # Cloudflare intermittently challenges non-browser UAs on the gateway;
+        # a browser UA keeps the poll stable.
+        "User-Agent": (
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+        ),
+    }
+
+    for _attempt in range(2):
+        request = urllib.request.Request(usage_url(), headers=headers)
+        try:
+            with urllib.request.urlopen(request, timeout=POLL_TIMEOUT_SEC) as response:
+                body = response.read()
+                break
+        except OSError:
+            # URLError (incl. HTTPError) and socket.timeout are OSError subclasses.
+            pass
+    else:
         return None
     try:
         payload = json.loads(body)

--- a/src/opencode_go_proxy/vision.py
+++ b/src/opencode_go_proxy/vision.py
@@ -30,7 +30,7 @@ from typing import Any
 
 from .errors import ProxyError
 from .meter import record_usage_event
-from .protocol import IMAGE_MODEL_DEFAULT
+from .protocol import IMAGE_MODEL_DEFAULT, _catalog_mtime
 
 # Caption cache: the same screenshot bytes are re-sent on every tool call of a
 # turn, and each re-caption costs a full upstream round trip. Key by the raw
@@ -285,24 +285,37 @@ def supports_image_input(model: dict[str, Any]) -> bool:
     return "image" in (model.get("input_modalities") or [])
 
 
+# Single-slot mtime cache for the catalog read below; the catalog is parsed
+# once per change instead of on every caption turn.
+_CATALOG_MODELS_CACHE: tuple[str, int | None, list[dict[str, Any]]] | None = None
+
+
 def catalog_image_models() -> list[dict[str, Any]]:
     """Image-capable, listed models from the full-shape state catalog."""
-    from . import catalog as _catalog
+    global _CATALOG_MODELS_CACHE
 
-    path = _catalog.default_catalog_path()
+    path, mtime = _catalog_mtime()
+    if (
+        _CATALOG_MODELS_CACHE is not None
+        and _CATALOG_MODELS_CACHE[0] == path
+        and _CATALOG_MODELS_CACHE[1] == mtime
+    ):
+        return _CATALOG_MODELS_CACHE[2]
     try:
         with open(path, encoding="utf-8") as handle:
             data = json.load(handle)
     except (OSError, json.JSONDecodeError):
-        return []
+        data = None
     models = data.get("models") if isinstance(data, dict) else None
     if not isinstance(models, list):
-        return []
-    return [
+        models = []
+    image_models = [
         m
         for m in models
         if isinstance(m, dict) and supports_image_input(m) and m.get("visibility", "list") == "list"
     ]
+    _CATALOG_MODELS_CACHE = (path, mtime, image_models)
+    return image_models
 
 
 # The catalog carries no per-token prices, so name-tier hints rank engines by
@@ -347,7 +360,11 @@ DEFAULT_LOCAL_VISION_BASE_URL = "http://127.0.0.1:11434/v1"
 DEFAULT_LOCAL_VISION_MODEL = "qwen2.5vl:3b"
 LOCAL_PROBE_TIMEOUT_SEC = 1.5
 _LOCAL_PROBE_TTL_SEC = 30.0
+_LOCAL_PROBE_MAX_ENTRIES = 64
 
+# (base_url, model) -> (probed_at, enabled). Bounded: expired entries are
+# swept on every access and the oldest entry is evicted past the cap, so a
+# turn that probes many runtimes can never grow this without limit.
 _LOCAL_PROBE_CACHE: dict[tuple[str, str], tuple[float, bool]] = {}
 
 
@@ -393,11 +410,17 @@ def local_runtime_enabled(*, base_url: str | None = None, model: str | None = No
     model = model or local_vision_model()
     key = (base_url, model)
     now = time.time()
+    stale = [k for k, (probed_at, _enabled) in _LOCAL_PROBE_CACHE.items() if now - probed_at >= _LOCAL_PROBE_TTL_SEC]
+    for stale_key in stale:
+        del _LOCAL_PROBE_CACHE[stale_key]
     cached = _LOCAL_PROBE_CACHE.get(key)
-    if cached is not None and now - cached[0] < _LOCAL_PROBE_TTL_SEC:
+    if cached is not None:
         return cached[1]
     enabled = _probe_local(base_url, model)
     _LOCAL_PROBE_CACHE[key] = (now, enabled)
+    if len(_LOCAL_PROBE_CACHE) > _LOCAL_PROBE_MAX_ENTRIES:
+        oldest_key = min(_LOCAL_PROBE_CACHE, key=lambda k: _LOCAL_PROBE_CACHE[k][0])
+        del _LOCAL_PROBE_CACHE[oldest_key]
     return enabled
 
 

--- a/src/opencode_go_proxy/zen_catalog.py
+++ b/src/opencode_go_proxy/zen_catalog.py
@@ -1,0 +1,385 @@
+"""Zen model catalog: capture the opencode.ai Zen model list and resolve families.
+
+The Zen gateway (https://opencode.ai/zen/v1) serves each model through one of
+four upstream surfaces:
+
+- anthropic_messages: /zen/v1/messages with x-api-key (claude-*, qwen*)
+- google_gemini: /zen/v1/models/<id> with x-goog-api-key (gemini-*)
+- openai_responses: /zen/v1/responses with Authorization: Bearer (gpt-*, grok-*)
+- openai_chat: /zen/v1/chat/completions with Bearer (everything else)
+
+The model list comes from GET /zen/v1/models (no auth) and is cached under the
+state dir (zen-models.json) with a fetched_at + TTL gate mirroring
+catalog.refresh_catalog. Families resolve per model from models.dev metadata
+(when present) with id-prefix rules as fallback, and persist to
+zen-catalog.json. Reads (zen_model_ids, zen_families) are cached in memory by
+file mtime, like routing.native_model_slugs, so a rewritten cache file is
+picked up without a restart. Capture never raises: a fetch failure falls back
+to the cached list, and with nothing cached the capture is empty.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import os
+import tempfile
+import urllib.error
+import urllib.request
+from typing import Any
+
+from . import __version__
+from .meter import state_dir
+from .trace import trace
+
+Json = dict[str, Any]
+
+ZEN_PREFIX = "zen/"
+
+ZEN_MODELS_URL = "https://opencode.ai/zen/v1/models"
+MODELS_DEV_URL = "https://models.dev/api.json"
+ZEN_MODELS_NAME = "zen-models.json"
+ZEN_CATALOG_NAME = "zen-catalog.json"
+
+DEFAULT_TTL_HOURS = 24
+ZEN_MODELS_REFRESH_ENV = "OPENCODE_GO_ZEN_MODELS_REFRESH"
+ZEN_FETCH_TIMEOUT_SEC = 10
+ZEN_FETCH_RETRIES = 1  # one retry on top of the first attempt
+MODELS_DEV_TIMEOUT_SEC = 10
+
+# models.dev family values for the opencode provider are specific (claude-opus,
+# gpt-codex, gemini-flash, deepseek-flash, qwen3.5, ...): the generic
+# vocabulary below maps directly, the big three classify by prefix, and
+# anything else stays unmapped so the id-prefix fallback decides. qwen models,
+# for example, speak the anthropic messages surface on zen even though
+# models.dev groups them with the compatible crowd.
+_MODELS_DEV_FAMILY_TO_ZEN = {
+    "anthropic": "anthropic_messages",
+    "google": "google_gemini",
+    "openai": "openai_responses",
+    "openai-compatible": "openai_chat",
+}
+
+
+class ZenModelFetchError(Exception):
+    """Raised when the zen model list cannot be fetched or parsed."""
+
+
+def zen_models_path() -> str:
+    """Path of the raw zen model-list cache under the state dir."""
+    return os.path.join(state_dir(), ZEN_MODELS_NAME)
+
+
+def zen_catalog_path() -> str:
+    """Path of the persisted zen family map under the state dir."""
+    return os.path.join(state_dir(), ZEN_CATALOG_NAME)
+
+
+def resolve_family(model_id: str, models_dev_families: dict[str, str] | None = None) -> str:
+    """Zen family for a bare model id.
+
+    Prefers the models.dev family metadata (provider "opencode") when it maps
+    to a zen family; otherwise the id-prefix rules decide.
+    """
+    if models_dev_families:
+        mapped = _zen_family_from_models_dev(models_dev_families.get(model_id))
+        if mapped:
+            return mapped
+    return _family_from_prefix(model_id)
+
+
+def _family_from_prefix(model_id: str) -> str:
+    lower = model_id.lower()
+    if lower.startswith(("claude", "qwen")):
+        return "anthropic_messages"
+    if lower.startswith("gemini"):
+        return "google_gemini"
+    if lower.startswith(("gpt", "grok")):
+        return "openai_responses"
+    return "openai_chat"
+
+
+def _zen_family_from_models_dev(family: str | None) -> str | None:
+    """Map a models.dev family value to a zen family; None when unmapped."""
+    if not family:
+        return None
+    value = str(family).strip().lower()
+    if value in _MODELS_DEV_FAMILY_TO_ZEN:
+        return _MODELS_DEV_FAMILY_TO_ZEN[value]
+    if value.startswith("claude"):
+        return "anthropic_messages"
+    if value.startswith("gemini"):
+        return "google_gemini"
+    if value.startswith(("gpt", "grok")):
+        return "openai_responses"
+    return None
+
+
+def _parse_iso(value: str) -> datetime.datetime:
+    """Parse an ISO timestamp, assuming UTC when no timezone is present."""
+    parsed = datetime.datetime.fromisoformat(value)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=datetime.UTC)
+    return parsed
+
+
+def _write_json(path: str, value: dict) -> None:
+    """Write JSON atomically (temp file + rename) so readers never see a partial file."""
+    directory = os.path.dirname(path) or "."
+    os.makedirs(directory, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=".zen-", suffix=".json", dir=directory)
+    try:
+        with os.fdopen(fd, "w") as handle:
+            json.dump(value, handle, indent=2)
+            handle.write("\n")
+        os.replace(tmp, path)
+    except BaseException:
+        # A leftover temp file is inert: the rename never happened, so readers
+        # keep the last good capture. Log when even the cleanup fails.
+        try:
+            os.unlink(tmp)
+        except OSError as exc:
+            trace("zen_catalog.cleanup_failed", path=tmp, error=str(exc))
+        raise
+
+
+def _load_capture(path: str) -> dict | None:
+    """Load a zen capture file; None when missing or malformed."""
+    try:
+        with open(path) as handle:
+            payload = json.load(handle)
+    except FileNotFoundError:
+        return None
+    except (OSError, json.JSONDecodeError) as exc:
+        trace("zen_catalog.load_failed", path=path, error=str(exc))
+        return None
+    if not isinstance(payload, dict) or not isinstance(payload.get("models"), list):
+        return None
+    return payload
+
+
+def _fetch_zen_models(timeout: int = ZEN_FETCH_TIMEOUT_SEC) -> list[dict]:
+    """GET /zen/v1/models; returns the data entries; raises ZenModelFetchError.
+
+    The endpoint needs no auth. One retry. The request identifies itself the
+    way discover_models does, since models.dev rejects the default urllib
+    User-Agent.
+    """
+    request = urllib.request.Request(
+        ZEN_MODELS_URL, headers={"User-Agent": f"opencode-go-proxy/{__version__}"}
+    )
+    last_error: Exception | None = None
+    for attempt in range(ZEN_FETCH_RETRIES + 1):
+        try:
+            with urllib.request.urlopen(request, timeout=timeout) as resp:
+                payload = json.load(resp)
+            data = payload.get("data") if isinstance(payload, dict) else None
+            if not isinstance(data, list):
+                raise ZenModelFetchError(f"unexpected payload shape from {ZEN_MODELS_URL}")
+            return [entry for entry in data if isinstance(entry, dict)]
+        except (
+            urllib.error.URLError,
+            TimeoutError,
+            OSError,
+            json.JSONDecodeError,
+            ZenModelFetchError,
+        ) as exc:
+            last_error = exc
+    raise ZenModelFetchError(f"failed to fetch {ZEN_MODELS_URL}: {last_error}")
+
+
+def _fetch_models_dev_families(timeout: int = MODELS_DEV_TIMEOUT_SEC) -> dict[str, str]:
+    """Best-effort {model_id: family} from the models.dev "opencode" provider.
+
+    Family metadata is a refinement, never a hard dependency: a failure
+    returns {} and capture falls back to the prefix rules.
+    """
+    request = urllib.request.Request(
+        MODELS_DEV_URL, headers={"User-Agent": f"opencode-go-proxy/{__version__}"}
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as resp:
+            payload = json.load(resp)
+    except (urllib.error.URLError, TimeoutError, OSError, json.JSONDecodeError) as exc:
+        trace("zen_catalog.models_dev_failed", error=str(exc))
+        return {}
+    provider = payload.get("opencode") if isinstance(payload, dict) else None
+    models = provider.get("models") if isinstance(provider, dict) else None
+    if not isinstance(models, dict):
+        return {}
+    families: dict[str, str] = {}
+    for model_id, entry in models.items():
+        if isinstance(entry, dict) and entry.get("family"):
+            families[str(model_id)] = str(entry["family"])
+    return families
+
+
+def _is_fresh(capture: dict, now: datetime.datetime, ttl_hours: float) -> bool:
+    """True when the capture's fetched_at is within the TTL window."""
+    fetched_at = capture.get("fetched_at")
+    if not isinstance(fetched_at, str):
+        return False
+    try:
+        fetched = _parse_iso(fetched_at)
+    except ValueError:
+        return False
+    return now - fetched < datetime.timedelta(hours=ttl_hours)
+
+
+def _resolve_families(model_ids: list[str], models_dev_families: dict[str, str]) -> dict[str, str]:
+    return {model_id: resolve_family(model_id, models_dev_families) for model_id in model_ids}
+
+
+def capture_zen_models(
+    now: datetime.datetime | None = None,
+    ttl_hours: float = DEFAULT_TTL_HOURS,
+    force: bool = False,
+) -> dict:
+    """Refresh the zen model capture when stale; never raises on network failure.
+
+    Mirrors catalog.refresh_catalog's TTL pattern: a cache whose fetched_at is
+    within ttl_hours skips the network, and OPENCODE_GO_ZEN_MODELS_REFRESH=0
+    disables it entirely. A successful fetch persists the raw list to
+    zen-models.json and the resolved families to zen-catalog.json. On fetch
+    failure the cached capture is returned when present, else an empty models
+    list. Returns {"fetched_at": iso, "models": [entry, ...]}.
+    """
+    if now is None:
+        now = datetime.datetime.now(datetime.UTC)
+    iso = now.isoformat()
+    models_path = zen_models_path()
+
+    if os.environ.get(ZEN_MODELS_REFRESH_ENV) == "0":
+        cached = _load_capture(models_path)
+        return cached if cached is not None else {"fetched_at": iso, "models": []}
+
+    if not force:
+        cached = _load_capture(models_path)
+        if cached is not None and _is_fresh(cached, now, ttl_hours):
+            return cached
+
+    try:
+        entries = _fetch_zen_models()
+    except ZenModelFetchError as exc:
+        trace("zen_catalog.fetch_failed", error=str(exc))
+        cached = _load_capture(models_path)
+        return cached if cached is not None else {"fetched_at": iso, "models": []}
+
+    model_ids = [str(entry["id"]) for entry in entries if isinstance(entry, dict) and entry.get("id")]
+    models_dev_families = _fetch_models_dev_families() if model_ids else {}
+    families = _resolve_families(model_ids, models_dev_families)
+    _write_json(models_path, {"fetched_at": iso, "models": entries})
+    _write_json(
+        zen_catalog_path(),
+        {
+            "version": 1,
+            "fetched_at": iso,
+            "models": {model_id: {"family": families[model_id]} for model_id in sorted(families)},
+        },
+    )
+    return {"fetched_at": iso, "models": entries}
+
+
+_ZEN_MODELS_CACHE: tuple[str, int | None, frozenset[str]] | None = None
+
+
+def zen_model_ids() -> set[str]:
+    """Bare zen model ids from the capture cache, refreshed by file mtime.
+
+    An empty set when the capture has not run or is unreadable.
+    """
+    global _ZEN_MODELS_CACHE
+    path = zen_models_path()
+    try:
+        mtime = os.stat(path).st_mtime_ns
+    except OSError:
+        mtime = None
+    if (
+        _ZEN_MODELS_CACHE is not None
+        and _ZEN_MODELS_CACHE[0] == path
+        and _ZEN_MODELS_CACHE[1] == mtime
+    ):
+        return set(_ZEN_MODELS_CACHE[2])
+    model_ids: frozenset[str] = frozenset()
+    if mtime is not None:
+        capture = _load_capture(path)
+        model_ids = frozenset(
+            str(entry["id"]) for entry in capture["models"] if isinstance(entry, dict) and entry.get("id")
+        )
+    _ZEN_MODELS_CACHE = (path, mtime, model_ids)
+    return set(model_ids)
+
+
+_ZEN_FAMILIES_CACHE: tuple[str, int | None, str, int | None, dict[str, str]] | None = None
+
+
+def zen_families() -> dict[str, str]:
+    """Bare zen model id -> zen family, refreshed by file mtime.
+
+    Persisted families from zen-catalog.json win. Ids the capture knows but
+    the persisted map misses resolve on the fly with the prefix rules, so the
+    two cache files can drift (for example zen-catalog.json deleted) without
+    leaving holes.
+    """
+    global _ZEN_FAMILIES_CACHE
+    catalog_path = zen_catalog_path()
+    models_path = zen_models_path()
+    catalog_mtime = _file_mtime(catalog_path)
+    models_mtime = _file_mtime(models_path)
+    if (
+        _ZEN_FAMILIES_CACHE is not None
+        and _ZEN_FAMILIES_CACHE[0] == catalog_path
+        and _ZEN_FAMILIES_CACHE[1] == catalog_mtime
+        and _ZEN_FAMILIES_CACHE[2] == models_path
+        and _ZEN_FAMILIES_CACHE[3] == models_mtime
+    ):
+        return dict(_ZEN_FAMILIES_CACHE[4])
+    families = _read_persisted_families(catalog_path)
+    for model_id in sorted(zen_model_ids() - set(families)):
+        families[model_id] = _family_from_prefix(model_id)
+    _ZEN_FAMILIES_CACHE = (catalog_path, catalog_mtime, models_path, models_mtime, families)
+    return dict(families)
+
+
+def _file_mtime(path: str) -> int | None:
+    try:
+        return os.stat(path).st_mtime_ns
+    except OSError:
+        return None
+
+
+def _read_persisted_families(path: str) -> dict[str, str]:
+    """{id: family} from zen-catalog.json; {} when missing or malformed."""
+    try:
+        with open(path) as handle:
+            payload = json.load(handle)
+    except FileNotFoundError:
+        return {}
+    except (OSError, json.JSONDecodeError) as exc:
+        trace("zen_catalog.read_failed", path=path, error=str(exc))
+        return {}
+    raw = payload.get("models") if isinstance(payload, dict) else None
+    if not isinstance(raw, dict):
+        return {}
+    families: dict[str, str] = {}
+    for model_id, meta in raw.items():
+        if isinstance(meta, dict) and meta.get("family"):
+            families[str(model_id)] = str(meta["family"])
+    return families
+
+
+__all__ = [
+    "DEFAULT_TTL_HOURS",
+    "MODELS_DEV_URL",
+    "ZEN_MODELS_NAME",
+    "ZEN_MODELS_REFRESH_ENV",
+    "ZEN_MODELS_URL",
+    "ZEN_PREFIX",
+    "ZenModelFetchError",
+    "capture_zen_models",
+    "resolve_family",
+    "zen_catalog_path",
+    "zen_families",
+    "zen_model_ids",
+    "zen_models_path",
+]

--- a/src/opencode_go_proxy/zen_upstream.py
+++ b/src/opencode_go_proxy/zen_upstream.py
@@ -1,0 +1,1593 @@
+"""Zen upstream client: per-family wire translation to opencode.ai/zen/v1.
+
+The Zen gateway serves each model through one of four surfaces, picked by
+``zen_families()[bare_id]``:
+
+- openai_chat: POST /zen/v1/chat/completions with ``Authorization: Bearer``
+- openai_responses: POST /zen/v1/responses with ``Authorization: Bearer``
+- anthropic_messages: POST /zen/v1/messages with ``x-api-key``
+- google_gemini: POST /zen/v1/models/<id> with ``x-goog-api-key``
+
+Every Responses-API request is translated to the family's wire shape and the
+family's SSE stream is translated back to Responses events, so the Codex app
+sees one uniform Responses stream no matter which surface the model speaks.
+The responses family is the exception: it is relayed verbatim. All zen turns
+meter with ``provider="zen"`` so they never count against the opencode-go
+quota. Zen requests are reachable only through the ``zen/`` model prefix; a
+bare id that happens to match a zen model stays on the opencode-go path.
+"""
+
+from __future__ import annotations
+
+import http.client
+import json
+import os
+import threading
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
+from http import HTTPStatus
+from typing import Any
+
+from .config import ProxyConfig
+from .errors import ProxyError
+from .meter import (
+    DEFAULT_ESTIMATE_CONTEXT_WINDOW,
+    estimate_input_tokens,
+    note_real_input_tokens,
+    record_usage_event,
+)
+from .passthrough import _relay_stream
+from .protocol import (
+    DEFAULT_MODEL,
+    _normalize_image_url,
+    chat_completion_to_response,
+    chat_message_to_response_output,
+    flatten_content,
+    inject_session_model,
+    model_context_window,
+    new_response_id,
+    normalize_usage,
+    now_unix,
+    responses_input_to_chat_messages,
+    responses_payload_to_chat_payload,
+    responses_tools_to_chat_tools,
+)
+from .secrets import resolve_api_key
+from .streaming import _ConnectFailed, _open_upstream_stream, keepalive_sec
+from .trace import _mask_trace_body, trace
+from .upstream import (
+    default_max_retries,
+    record_cache,
+    retriable_http_status,
+    retry_sleep,
+    usage_tokens,
+)
+from .zen_catalog import ZEN_PREFIX, resolve_family, zen_families, zen_model_ids
+
+Json = dict[str, Any]
+
+ZEN_BASE_URL_DEFAULT = "https://opencode.ai/zen/v1"
+ZEN_BASE_URL_ENV = "OPENCODE_ZEN_BASE_URL"
+ZEN_PROVIDER = "zen"
+ANTHROPIC_VERSION = "2023-06-01"
+DEFAULT_ANTHROPIC_MAX_TOKENS = 8192
+
+# The four zen wire families; anything else is a catalog bug and must not be
+# forwarded to an endpoint that will reject it.
+ZEN_FAMILY_VALUES = frozenset(
+    {"anthropic_messages", "google_gemini", "openai_responses", "openai_chat"}
+)
+
+# The chat-completions family streams DeepSeek-style reasoning deltas; the
+# anthropic and gemini families send none for now.
+REASONING_DELTA_KEYS = ("reasoning_content",)
+
+
+def zen_base_url() -> str:
+    """Zen upstream base: env override, then the opencode.ai default."""
+    return (os.environ.get(ZEN_BASE_URL_ENV) or ZEN_BASE_URL_DEFAULT).rstrip("/")
+
+
+def bare_zen_id(slug: str) -> str:
+    """Strip the ``zen/`` provider prefix; any other slug is unchanged."""
+    if slug.startswith(ZEN_PREFIX):
+        return slug[len(ZEN_PREFIX):]
+    return slug
+
+
+def ensure_zen_slug(model: str) -> None:
+    """Refuse to route a model without the zen prefix through the zen client.
+
+    A bare slug that happens to match a zen id must stay on the opencode-go
+    path; if one arrives here the caller routed wrong.
+    """
+    if not model.startswith(ZEN_PREFIX):
+        raise ProxyError(
+            HTTPStatus.BAD_REQUEST,
+            f"zen routing requires the '{ZEN_PREFIX}' model prefix (got {model!r})",
+        )
+
+
+def zen_family_for(bare_id: str) -> str:
+    """Zen wire family for a bare id.
+
+    The persisted family map wins. An id the map misses but the model capture
+    knows resolves from the id prefix (the catalog's own fallback), and
+    anything else lands on the chat-completions surface zen uses for the rest.
+    """
+    family = zen_families().get(bare_id)
+    if family in ZEN_FAMILY_VALUES:
+        return family
+    if bare_id in zen_model_ids():
+        resolved = resolve_family(bare_id)
+        if resolved in ZEN_FAMILY_VALUES:
+            return resolved
+    return "openai_chat"
+
+
+def _user_agent() -> str:
+    return os.environ.get("OPENCODE_GO_PROXY_USER_AGENT", "codex/1.0")
+
+
+def _zen_endpoint(family: str, bare_id: str, *, stream: bool) -> str:
+    """Per-family zen path for the bare model id."""
+    base = zen_base_url()
+    if family == "openai_responses":
+        return f"{base}/responses"
+    if family == "openai_chat":
+        return f"{base}/chat/completions"
+    if family == "anthropic_messages":
+        return f"{base}/messages"
+    quoted = urllib.parse.quote(bare_id, safe="")
+    if stream:
+        return f"{base}/models/{quoted}:streamGenerateContent?alt=sse"
+    return f"{base}/models/{quoted}:generateContent"
+
+
+def _zen_headers(family: str, api_key: str, *, stream: bool) -> dict[str, str]:
+    """Per-family auth and accept headers."""
+    accept = "text/event-stream" if stream else "application/json"
+    headers = {
+        "content-type": "application/json",
+        "accept": accept,
+        "user-agent": _user_agent(),
+    }
+    if family == "anthropic_messages":
+        headers["x-api-key"] = api_key
+        headers["anthropic-version"] = ANTHROPIC_VERSION
+    elif family == "google_gemini":
+        headers["x-goog-api-key"] = api_key
+    else:
+        headers["authorization"] = f"Bearer {api_key}"
+    return headers
+
+
+def parse_zen_error(body: str) -> tuple[str | None, str | None]:
+    """Extract (error_type, message) from a zen error envelope.
+
+    Zen errors look like ``{"type":"error","error":{"type":"<Class>",
+    "message":"..."},"metadata":{...}}``; the plain OpenAI
+    ``{"error":{"message":...}}`` shape is accepted too. Unparseable bodies
+    yield ``(None, None)`` and the caller falls back to a status message.
+    """
+    try:
+        value = json.loads(body)
+    except json.JSONDecodeError:
+        return None, None
+    if not isinstance(value, dict):
+        return None, None
+    error = value.get("error")
+    if isinstance(error, dict):
+        error_type = error.get("type")
+        message = error.get("message")
+        return (
+            error_type if isinstance(error_type, str) else None,
+            message if isinstance(message, str) else None,
+        )
+    message = value.get("message")
+    return None, message if isinstance(message, str) else None
+
+
+def _build_zen_request(
+    payload: Json,
+    family: str,
+    bare_id: str,
+    api_key: str,
+    *,
+    stream: bool,
+    session_model: str,
+) -> tuple[str, Json, dict[str, str]]:
+    """Return ``(url, body, headers)`` for one zen upstream call.
+
+    ``session_model`` is the prefixed slug the app knows; the wire body always
+    addresses the upstream with the bare id. Translated families get the
+    session model injected into create_thread calls (spawned threads inherit
+    the routed zen model); the verbatim responses family keeps the original
+    body apart from the model strip.
+    """
+    if family == "openai_responses":
+        working = dict(payload)
+        working["model"] = bare_id
+        url = _zen_endpoint(family, bare_id, stream=stream)
+        return url, working, _zen_headers(family, api_key, stream=stream)
+
+    if family == "openai_chat":
+        working = inject_session_model(dict(payload), session_model)
+        working["model"] = bare_id
+        chat_payload, _request_model, _stats = responses_payload_to_chat_payload(working)
+        # The catalog translation can rewrite the model (image fallback /
+        # unknown slug); the zen upstream is addressed with the bare zen id,
+        # never a substitute.
+        chat_payload["model"] = bare_id
+        if stream:
+            chat_payload["stream"] = True
+            chat_payload["stream_options"] = {"include_usage": True}
+        else:
+            chat_payload["stream"] = False
+        url = _zen_endpoint(family, bare_id, stream=stream)
+        return url, chat_payload, _zen_headers(family, api_key, stream=stream)
+
+    if family == "anthropic_messages":
+        working = inject_session_model(dict(payload), session_model)
+        working["model"] = bare_id
+        body = responses_payload_to_anthropic_payload(working)
+        body["stream"] = stream
+        url = _zen_endpoint(family, bare_id, stream=stream)
+        return url, body, _zen_headers(family, api_key, stream=stream)
+
+    working = inject_session_model(dict(payload), session_model)
+    body = responses_payload_to_gemini_payload(working)
+    url = _zen_endpoint(family, bare_id, stream=stream)
+    return url, body, _zen_headers(family, api_key, stream=stream)
+
+
+def _zen_post(
+    url: str,
+    raw_payload: bytes,
+    headers: dict[str, str],
+    config: ProxyConfig,
+    request_id: str,
+    *,
+    max_retries: int | None = None,
+) -> tuple[Json, int]:
+    """POST one JSON zen request with the shared retry policy.
+
+    Returns ``(parsed_json, retries)``. Transient failures (429 / 5xx /
+    network / timeout) retry with the upstream.py backoff; terminal errors
+    raise :class:`ProxyError` preserving the zen status code and envelope
+    type/message. On 429 the message carries the upstream retry-after.
+    """
+    max_retries = default_max_retries() if max_retries is None else max_retries
+    retries = 0
+    while True:
+        request = urllib.request.Request(url, data=raw_payload, headers=headers, method="POST")
+        trace("zen.start", request_id=request_id, url=url, bytes=len(raw_payload), attempt=retries + 1)
+        started = time.time()
+        try:
+            with urllib.request.urlopen(request, timeout=config.timeout_sec) as response:
+                body = response.read()
+                elapsed_ms = int((time.time() - started) * 1000)
+                trace("zen.done", request_id=request_id, status=response.status, bytes=len(body), elapsed_ms=elapsed_ms)
+                try:
+                    value = json.loads(body)
+                except json.JSONDecodeError:
+                    raise ProxyError(HTTPStatus.BAD_GATEWAY, "zen upstream returned invalid JSON", retries=retries)
+                if not isinstance(value, dict):
+                    raise ProxyError(HTTPStatus.BAD_GATEWAY, "zen upstream returned non-object JSON", retries=retries)
+                return value, retries
+        except urllib.error.HTTPError as exc:
+            body = exc.read().decode("utf-8", errors="replace")
+            trace("zen.error", request_id=request_id, status=exc.code, body=_mask_trace_body(body))
+            if retriable_http_status(exc.code) and retries < max_retries:
+                retries += 1
+                trace("zen.retry", request_id=request_id, attempt=retries, status=exc.code)
+                retry_sleep(retries)
+                continue
+            error_type, message = parse_zen_error(body)
+            if exc.code == 429:
+                retry_after = (exc.headers.get("retry-after", "5") if exc.headers else "5")
+                raise ProxyError(
+                    HTTPStatus.TOO_MANY_REQUESTS,
+                    f"rate limited (retry after {retry_after}s)",
+                    retries=retries,
+                    upstream_status=exc.code,
+                    error_type=error_type,
+                ) from exc
+            try:
+                status = HTTPStatus(exc.code)
+            except ValueError:
+                status = HTTPStatus.BAD_GATEWAY
+            raise ProxyError(
+                status,
+                message or f"zen upstream HTTP {exc.code}",
+                retries=retries,
+                upstream_status=exc.code,
+                error_type=error_type,
+            ) from exc
+        except urllib.error.URLError as exc:
+            trace("zen.network_error", request_id=request_id, reason=str(getattr(exc, "reason", exc)))
+            if retries < max_retries:
+                retries += 1
+                trace("zen.retry", request_id=request_id, attempt=retries, reason=str(getattr(exc, "reason", exc)))
+                retry_sleep(retries)
+                continue
+            raise ProxyError(HTTPStatus.BAD_GATEWAY, f"zen upstream network error: {getattr(exc, 'reason', exc)}", retries=retries) from exc
+        except TimeoutError:
+            trace("zen.timeout", request_id=request_id, timeout=config.timeout_sec)
+            if retries < max_retries:
+                retries += 1
+                trace("zen.retry", request_id=request_id, attempt=retries, reason="timeout")
+                retry_sleep(retries)
+                continue
+            raise ProxyError(HTTPStatus.GATEWAY_TIMEOUT, "zen upstream timeout", retries=retries) from None
+
+
+def _zen_post_verbatim(
+    url: str,
+    raw_payload: bytes,
+    headers: dict[str, str],
+    config: ProxyConfig,
+    request_id: str,
+    *,
+    max_retries: int | None = None,
+) -> tuple[int, bytes, int, str | None, str | None]:
+    """POST one zen request and return ``(status, raw_body, retries, content_type, retry_after)``.
+
+    The verbatim relay path: an upstream HTTP error is returned with the
+    upstream's own status and body so the proxy relays it unchanged instead of
+    substituting a ``proxy_error`` envelope. Network and timeout failures have
+    no upstream body to relay, so they still raise :class:`ProxyError`.
+    """
+    max_retries = default_max_retries() if max_retries is None else max_retries
+    retries = 0
+    while True:
+        request = urllib.request.Request(url, data=raw_payload, headers=headers, method="POST")
+        trace("zen.start", request_id=request_id, url=url, bytes=len(raw_payload), attempt=retries + 1)
+        started = time.time()
+        try:
+            with urllib.request.urlopen(request, timeout=config.timeout_sec) as response:
+                body = response.read()
+                elapsed_ms = int((time.time() - started) * 1000)
+                trace("zen.done", request_id=request_id, status=response.status, bytes=len(body), elapsed_ms=elapsed_ms)
+                return response.status, body, retries, response.headers.get("content-type"), None
+        except urllib.error.HTTPError as exc:
+            body = exc.read()
+            trace("zen.error", request_id=request_id, status=exc.code, body=_mask_trace_body(body.decode("utf-8", errors="replace")))
+            if retriable_http_status(exc.code) and retries < max_retries:
+                retries += 1
+                trace("zen.retry", request_id=request_id, attempt=retries, status=exc.code)
+                retry_sleep(retries)
+                continue
+            retry_after = exc.headers.get("retry-after") if exc.headers else None
+            return exc.code, body, retries, (exc.headers.get("content-type") if exc.headers else None), retry_after
+        except urllib.error.URLError as exc:
+            trace("zen.network_error", request_id=request_id, reason=str(getattr(exc, "reason", exc)))
+            if retries < max_retries:
+                retries += 1
+                trace("zen.retry", request_id=request_id, attempt=retries, reason=str(getattr(exc, "reason", exc)))
+                retry_sleep(retries)
+                continue
+            raise ProxyError(HTTPStatus.BAD_GATEWAY, f"zen upstream network error: {getattr(exc, 'reason', exc)}", retries=retries) from exc
+        except TimeoutError:
+            trace("zen.timeout", request_id=request_id, timeout=config.timeout_sec)
+            if retries < max_retries:
+                retries += 1
+                trace("zen.retry", request_id=request_id, attempt=retries, reason="timeout")
+                retry_sleep(retries)
+                continue
+            raise ProxyError(HTTPStatus.GATEWAY_TIMEOUT, "zen upstream timeout", retries=retries) from None
+
+
+def _zen_tokens(value: Json, family: str) -> tuple[Any, Any, Any]:
+    """(input, output, total) token counts from a family-shaped response."""
+    if family == "openai_chat":
+        usage = value.get("usage") if isinstance(value, dict) else None
+        return usage_tokens(usage)
+    usage = value.get("usage") if isinstance(value, dict) else None
+    if family == "openai_responses" and isinstance(usage, dict):
+        return usage.get("input_tokens"), usage.get("output_tokens"), usage.get("total_tokens")
+    if family == "anthropic_messages" and isinstance(usage, dict):
+        inp = usage.get("input_tokens")
+        outp = usage.get("output_tokens")
+        total = inp + outp if isinstance(inp, int) and isinstance(outp, int) else None
+        return inp, outp, total
+    metadata = value.get("usageMetadata") if isinstance(value, dict) else None
+    if isinstance(metadata, dict):
+        return (
+            metadata.get("promptTokenCount"),
+            metadata.get("candidatesTokenCount"),
+            metadata.get("totalTokenCount"),
+        )
+    return None, None, None
+
+
+def _usage_to_openai_shape(usage: Json) -> Json:
+    """Normalize a family usage object to input/output/total token keys."""
+    normalized: Json = {
+        "input_tokens": usage.get("input_tokens"),
+        "output_tokens": usage.get("output_tokens"),
+        "total_tokens": usage.get("total_tokens"),
+    }
+    return {key: value for key, value in normalized.items() if value is not None}
+
+
+def _image_url(part: Json) -> str | None:
+    """Extract a safe image URL from a chat-style image part, if any."""
+    normalized = _normalize_image_url(part)
+    if normalized is None:
+        return None
+    url = (normalized.get("image_url") or {}).get("url")
+    return url if isinstance(url, str) and url else None
+
+
+def responses_payload_to_anthropic_payload(payload: Json) -> Json:
+    """Translate a Responses payload to the Anthropic Messages shape.
+
+    instructions and system messages become the top-level ``system`` list;
+    chat messages map to anthropic roles (tool results become user messages
+    with ``tool_result`` blocks, assistant tool calls become ``tool_use``
+    content blocks); tools map to ``input_schema`` declarations. Consecutive
+    same-role turns are allowed: the Anthropic API combines them.
+    """
+    messages, _stats = responses_input_to_chat_messages(payload)
+    tools, _tool_stats = responses_tools_to_chat_tools(payload.get("tools"))
+
+    system_parts: list[str] = []
+
+    anthropic_messages: list[Json] = []
+    for message in messages:
+        role = message.get("role")
+        content = message.get("content")
+        if role == "system":
+            text = flatten_content(content)
+            if text:
+                system_parts.append(text)
+            continue
+        if role == "tool":
+            anthropic_messages.append(
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": message.get("tool_call_id") or "",
+                            "content": _tool_result_text(content),
+                        }
+                    ],
+                }
+            )
+            continue
+        if role == "assistant":
+            blocks: list[Json] = []
+            text = flatten_content(content)
+            if text:
+                blocks.append({"type": "text", "text": text})
+            for tool_call in message.get("tool_calls") or []:
+                if not isinstance(tool_call, dict):
+                    continue
+                function = tool_call.get("function") or {}
+                arguments = function.get("arguments", "{}")
+                try:
+                    parsed = json.loads(arguments) if isinstance(arguments, str) and arguments else {}
+                except (ValueError, TypeError):
+                    parsed = {}
+                blocks.append(
+                    {
+                        "type": "tool_use",
+                        "id": tool_call.get("id") or f"call_{uuid.uuid4().hex}",
+                        "name": function.get("name", ""),
+                        "input": parsed,
+                    }
+                )
+            if blocks:
+                anthropic_messages.append({"role": "assistant", "content": blocks})
+            continue
+        blocks = _anthropic_user_blocks(content)
+        if blocks:
+            anthropic_messages.append({"role": "user", "content": blocks})
+
+    body: Json = {"model": "", "messages": anthropic_messages}
+    if system_parts:
+        body["system"] = system_parts
+    max_tokens = payload.get("max_output_tokens")
+    body["max_tokens"] = max_tokens if isinstance(max_tokens, int) and max_tokens > 0 else DEFAULT_ANTHROPIC_MAX_TOKENS
+    if payload.get("temperature") is not None:
+        body["temperature"] = payload["temperature"]
+    if tools:
+        body["tools"] = [
+            {
+                "name": tool["function"]["name"],
+                "description": tool["function"].get("description", ""),
+                "input_schema": tool["function"].get("parameters") or {"type": "object", "properties": {}},
+            }
+            for tool in tools
+            if isinstance(tool, dict) and isinstance(tool.get("function"), dict)
+        ]
+        tool_choice = _anthropic_tool_choice(payload.get("tool_choice"))
+        if tool_choice is not None:
+            body["tool_choice"] = tool_choice
+    return body
+
+
+def _tool_result_text(content: Any) -> str:
+    """Flatten a chat tool result to the string anthropic tool_result wants."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return flatten_content(content)
+    if content is None:
+        return ""
+    return json.dumps(content, separators=(",", ":"))
+
+
+def _anthropic_user_blocks(content: Any) -> list[Json]:
+    """Chat user content to anthropic content blocks (text + images)."""
+    if isinstance(content, str):
+        return [{"type": "text", "text": content}] if content else []
+    blocks: list[Json] = []
+    for part in content or []:
+        if isinstance(part, str):
+            if part:
+                blocks.append({"type": "text", "text": part})
+            continue
+        if not isinstance(part, dict):
+            continue
+        part_type = part.get("type")
+        if part_type in {"text", "input_text", "output_text"}:
+            text = part.get("text")
+            if isinstance(text, str) and text:
+                blocks.append({"type": "text", "text": text})
+            continue
+        if part_type in {"image_url", "input_image", "image"}:
+            url = _image_url(part)
+            if url and url.startswith("data:"):
+                header, _, data = url.partition(",")
+                media_type = header[len("data:"):].partition(";")[0] or "image/png"
+                blocks.append({"type": "image", "source": {"type": "base64", "media_type": media_type, "data": data}})
+            elif url and url.startswith("https://"):
+                blocks.append({"type": "image", "source": {"type": "url", "url": url}})
+    return blocks
+
+
+def _anthropic_tool_choice(choice: Any) -> Json | None:
+    """Responses tool_choice to anthropic tool_choice; None means omit (auto)."""
+    if isinstance(choice, str):
+        if choice == "required":
+            return {"type": "any"}
+        return None
+    if not isinstance(choice, dict):
+        return None
+    choice_type = choice.get("type")
+    if choice_type == "function":
+        name = choice.get("name")
+        if isinstance(name, str) and name:
+            return {"type": "tool", "name": name}
+        return {"type": "any"}
+    if choice_type == "required":
+        return {"type": "any"}
+    return None
+
+
+def responses_payload_to_gemini_payload(payload: Json) -> Json:
+    """Translate a Responses payload to the Gemini generateContent shape.
+
+    Chat messages map to contents (assistant -> model, tool results -> user
+    functionResponse parts, assistant tool calls -> functionCall parts);
+    instructions and system messages become systemInstruction; tools become
+    functionDeclarations. Consecutive same-role contents are merged, since
+    Gemini rejects non-alternating roles.
+    """
+    messages, _stats = responses_input_to_chat_messages(payload)
+    tools, _tool_stats = responses_tools_to_chat_tools(payload.get("tools"))
+
+    system_texts: list[str] = []
+
+    contents: list[Json] = []
+    call_id_to_name: dict[str, str] = {}
+
+    def append_content(role: str, parts: list[Json]) -> None:
+        if not parts:
+            return
+        if contents and contents[-1].get("role") == role:
+            contents[-1]["parts"].extend(parts)
+        else:
+            contents.append({"role": role, "parts": parts})
+
+    for message in messages:
+        role = message.get("role")
+        content = message.get("content")
+        if role == "system":
+            text = flatten_content(content)
+            if text:
+                system_texts.append(text)
+            continue
+        if role == "tool":
+            call_id = message.get("tool_call_id") or ""
+            name = call_id_to_name.get(call_id, call_id or "tool")
+            append_content(
+                "user",
+                [{"functionResponse": {"name": name, "response": _tool_result_value(content)}}],
+            )
+            continue
+        gemini_role = "model" if role == "assistant" else "user"
+        parts: list[Json] = []
+        if isinstance(content, str):
+            if content:
+                parts.append({"text": content})
+        elif isinstance(content, list):
+            for part in content:
+                if not isinstance(part, dict):
+                    continue
+                part_type = part.get("type")
+                if part_type in {"text", "input_text", "output_text"}:
+                    text = part.get("text")
+                    if isinstance(text, str) and text:
+                        parts.append({"text": text})
+                elif part_type in {"image_url", "input_image", "image"}:
+                    url = _image_url(part)
+                    if url and url.startswith("data:"):
+                        header, _, data = url.partition(",")
+                        media_type = header[len("data:"):].partition(";")[0] or "image/png"
+                        parts.append({"inlineData": {"mimeType": media_type, "data": data}})
+        for tool_call in message.get("tool_calls") or []:
+            if not isinstance(tool_call, dict):
+                continue
+            function = tool_call.get("function") or {}
+            call_id = tool_call.get("id") or ""
+            name = function.get("name", "")
+            if call_id:
+                call_id_to_name[call_id] = name
+            try:
+                arguments = json.loads(function.get("arguments", "{}")) if isinstance(function.get("arguments"), str) else {}
+            except (ValueError, TypeError):
+                arguments = {}
+            parts.append({"functionCall": {"name": name, "args": arguments}})
+        append_content(gemini_role, parts)
+
+    body: Json = {"contents": contents}
+    if system_texts:
+        body["systemInstruction"] = {"parts": [{"text": text} for text in system_texts]}
+    if tools:
+        declarations = [
+            {
+                "name": tool["function"]["name"],
+                "description": tool["function"].get("description", ""),
+                "parameters": tool["function"].get("parameters") or {"type": "object", "properties": {}},
+            }
+            for tool in tools
+            if isinstance(tool, dict) and isinstance(tool.get("function"), dict)
+        ]
+        if declarations:
+            body["tools"] = [{"functionDeclarations": declarations}]
+            tool_config = _gemini_tool_config(payload.get("tool_choice"), declarations)
+            if tool_config is not None:
+                body["toolConfig"] = tool_config
+    generation_config: Json = {}
+    if payload.get("temperature") is not None:
+        generation_config["temperature"] = payload["temperature"]
+    if payload.get("top_p") is not None:
+        generation_config["topP"] = payload["top_p"]
+    if payload.get("max_output_tokens") is not None:
+        generation_config["maxOutputTokens"] = payload["max_output_tokens"]
+    if generation_config:
+        body["generationConfig"] = generation_config
+    return body
+
+
+def _tool_result_value(content: Any) -> Any:
+    """Gemini functionResponse payload from a chat tool result."""
+    if isinstance(content, str):
+        try:
+            return json.loads(content)
+        except (ValueError, TypeError):
+            return {"value": content}
+    if isinstance(content, list):
+        return {"value": flatten_content(content)}
+    if content is None:
+        return {}
+    return content
+
+
+def _gemini_tool_config(choice: Any, declarations: list[Json]) -> Json | None:
+    """Responses tool_choice to a Gemini functionCallingConfig; None means omit (AUTO)."""
+    mode = "AUTO"
+    allowed: list[str] | None = None
+    if isinstance(choice, str):
+        if choice == "required":
+            mode = "ANY"
+        elif choice == "none":
+            mode = "NONE"
+    elif isinstance(choice, dict):
+        choice_type = choice.get("type")
+        if choice_type == "function":
+            name = choice.get("name")
+            if isinstance(name, str) and name and any(d.get("name") == name for d in declarations):
+                mode = "ANY"
+                allowed = [name]
+        elif choice_type == "required":
+            mode = "ANY"
+        elif choice_type == "none":
+            mode = "NONE"
+    config: Json = {"mode": mode}
+    if allowed:
+        config["allowedFunctionNames"] = allowed
+    return {"functionCallingConfig": config}
+
+
+def _anthropic_to_response(value: Json, model: str) -> Json:
+    """Anthropic messages response to the Responses object shape."""
+    fake, text_parts = _anthropic_content_to_fake(value.get("content"))
+    output = chat_message_to_response_output(fake)
+    usage = value.get("usage")
+    normalized_usage = None
+    if isinstance(usage, dict):
+        inp = usage.get("input_tokens")
+        outp = usage.get("output_tokens")
+        total = inp + outp if isinstance(inp, int) and isinstance(outp, int) else None
+        normalized_usage = normalize_usage(
+            {"input_tokens": inp, "output_tokens": outp, "total_tokens": total}
+        )
+    return {
+        "id": new_response_id(),
+        "object": "response",
+        "created_at": now_unix(),
+        "status": "completed",
+        "model": model,
+        "output": output,
+        "output_text": "".join(text_parts),
+        "usage": normalized_usage,
+    }
+
+
+def _anthropic_content_to_fake(content: Any) -> tuple[Json, list[str]]:
+    """Anthropic content blocks to (fake chat message, text parts)."""
+    text_parts: list[str] = []
+    tool_calls: list[Json] = []
+    for block in content or []:
+        if not isinstance(block, dict):
+            continue
+        block_type = block.get("type")
+        if block_type in {"text", "thinking"}:
+            text = block.get("text")
+            if isinstance(text, str) and text:
+                text_parts.append(text)
+        elif block_type == "tool_use":
+            arguments = block.get("input")
+            tool_calls.append(
+                {
+                    "id": block.get("id") or f"call_{uuid.uuid4().hex}",
+                    "type": "function",
+                    "function": {
+                        "name": block.get("name", ""),
+                        "arguments": (
+                            arguments
+                            if isinstance(arguments, str)
+                            else json.dumps(arguments, separators=(",", ":"))
+                        ),
+                    },
+                }
+            )
+    fake: Json = {}
+    if text_parts:
+        fake["content"] = "\n".join(text_parts)
+    if tool_calls:
+        fake["tool_calls"] = tool_calls
+    return fake, text_parts
+
+
+def _gemini_to_response(value: Json, model: str) -> Json:
+    """Gemini generateContent response to the Responses object shape."""
+    fake, text_parts = _gemini_content_to_fake(value)
+    output = chat_message_to_response_output(fake)
+    metadata = value.get("usageMetadata")
+    normalized_usage = None
+    if isinstance(metadata, dict):
+        inp = metadata.get("promptTokenCount")
+        outp = metadata.get("candidatesTokenCount")
+        total = metadata.get("totalTokenCount")
+        normalized_usage = normalize_usage(
+            {"input_tokens": inp, "output_tokens": outp, "total_tokens": total}
+        )
+    return {
+        "id": new_response_id(),
+        "object": "response",
+        "created_at": now_unix(),
+        "status": "completed",
+        "model": model,
+        "output": output,
+        "output_text": "".join(text_parts),
+        "usage": normalized_usage,
+    }
+
+
+def _gemini_content_to_fake(value: Json) -> tuple[Json, list[str]]:
+    """Gemini response to (fake chat message, text parts)."""
+    text_parts: list[str] = []
+    tool_calls: list[Json] = []
+    candidates = value.get("candidates") if isinstance(value, dict) else None
+    if not isinstance(candidates, list) or not candidates:
+        return {}, text_parts
+    first = candidates[0]
+    content = first.get("content") if isinstance(first, dict) else None
+    if not isinstance(content, dict):
+        return {}, text_parts
+    for part in content.get("parts") or []:
+        if not isinstance(part, dict):
+            continue
+        text = part.get("text")
+        if isinstance(text, str) and text and not part.get("thought"):
+            text_parts.append(text)
+        function_call = part.get("functionCall")
+        if isinstance(function_call, dict):
+            tool_calls.append(
+                {
+                    "id": f"call_{uuid.uuid4().hex}",
+                    "type": "function",
+                    "function": {
+                        "name": function_call.get("name", ""),
+                        "arguments": json.dumps(function_call.get("args") or {}, separators=(",", ":")),
+                    },
+                }
+            )
+    fake: Json = {}
+    if text_parts:
+        fake["content"] = "\n".join(text_parts)
+    if tool_calls:
+        fake["tool_calls"] = tool_calls
+    return fake, text_parts
+
+
+def _translate_response(value: Json, family: str, model: str) -> Json:
+    """Family-shaped non-stream response to the Responses object shape."""
+    if family == "openai_responses":
+        return value
+    if family == "openai_chat":
+        return chat_completion_to_response(value, request_model=model)
+    if family == "anthropic_messages":
+        return _anthropic_to_response(value, model)
+    return _gemini_to_response(value, model)
+
+
+def _meter_zen(
+    model: str,
+    started: float,
+    status: int,
+    *,
+    input_tokens: Any = None,
+    output_tokens: Any = None,
+    total_tokens: Any = None,
+    estimated_input_tokens: Any = None,
+    stream_aborted: bool = False,
+    empty_completion: bool = False,
+    retries: int | None = None,
+) -> None:
+    """Append one usage event with the zen provider so zen turns never count
+    against the opencode-go quota."""
+    record_usage_event(
+        model=model,
+        status=status,
+        duration_ms=int((time.time() - started) * 1000),
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        total_tokens=total_tokens,
+        estimated_input_tokens=estimated_input_tokens,
+        stream_aborted=stream_aborted,
+        empty_completion=empty_completion,
+        retries=retries,
+        provider=ZEN_PROVIDER,
+    )
+
+
+def _send_json(handler: Any, payload: Json, status: HTTPStatus = HTTPStatus.OK) -> None:
+    raw = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    handler.send_response(status)
+    handler.send_header("content-type", "application/json")
+    handler.send_header("content-length", str(len(raw)))
+    handler.end_headers()
+    handler.wfile.write(raw)
+
+
+def _relay_upstream_error(
+    handler: Any,
+    status: int,
+    body: bytes,
+    headers: Any,
+) -> None:
+    """Relay an upstream error status and body before any SSE is committed.
+
+    ``retry-after`` is forwarded when the upstream sent one (429 pacing).
+    """
+    content_type = (headers.get("content-type") if headers else None) or "application/json"
+    handler.send_response(status)
+    if headers:
+        retry_after = headers.get("retry-after")
+        if retry_after:
+            handler.send_header("retry-after", retry_after)
+    handler.send_header("content-type", content_type)
+    handler.send_header("content-length", str(len(body)))
+    handler.end_headers()
+    handler.wfile.write(body)
+    handler.wfile.flush()
+
+
+def call_zen_responses(payload: Json, config: ProxyConfig, request_id: str) -> Json:
+    """Non-stream Responses call: translate per family and return the response.
+
+    Metering is provider="zen" on success and on every ProxyError path; the
+    error is re-raised for the dispatcher to render.
+    """
+    started = time.time()
+    model = payload.get("model") or DEFAULT_MODEL
+    bare_id = bare_zen_id(model)
+    family = zen_family_for(bare_id)
+    api_key = resolve_api_key(config, request_id)
+    url, body, headers = _build_zen_request(
+        payload, family, bare_id, api_key, stream=False, session_model=model
+    )
+    raw_payload = json.dumps(body, separators=(",", ":")).encode("utf-8")
+    trace("zen.start", request_id=request_id, url=url, bytes=len(raw_payload), family=family, stream=False)
+    try:
+        value, retries = _zen_post(url, raw_payload, headers, config, request_id)
+    except ProxyError as exc:
+        _meter_zen(model, started, int(exc.status), retries=exc.retries or None)
+        raise
+    if family == "openai_chat":
+        record_cache(config.cache_tracker, body.get("model"), value.get("usage"))
+    inp, outp, total = _zen_tokens(value, family)
+    _meter_zen(
+        model, started, 200,
+        input_tokens=inp, output_tokens=outp, total_tokens=total,
+        retries=retries or None,
+    )
+    response = _translate_response(value, family, model)
+    trace(
+        "zen.done", request_id=request_id, family=family, stream=False,
+        output_items=len(response.get("output", [])),
+        output_text_len=len(response.get("output_text", "")),
+    )
+    return response
+
+
+class _ZenStreamEngine:
+    """Translate one zen SSE stream into Responses events.
+
+    The engine owns the SSE write lock, the keepalive thread, monotonic
+    output_index assignment, per-family chunk parsing, and zen metering. Tool
+    calls accumulate during the stream and are emitted complete at finalize
+    (the app reconciles items by id, so late emission is safe).
+    """
+
+    def __init__(
+        self,
+        handler: Any,
+        payload: Json,
+        config: ProxyConfig,
+        request_id: str,
+        *,
+        family: str,
+        bare_id: str,
+        model: str,
+        response_id: str,
+        started: float,
+        raw_payload: bytes,
+    ) -> None:
+        self.handler = handler
+        self.config = config
+        self.request_id = request_id
+        self.family = family
+        self.bare_id = bare_id
+        self.model = model
+        self.response_id = response_id
+        self.started = started
+        self.raw_payload = raw_payload
+        self.retries = 0
+
+        self.client_alive = True
+        self.keepalive_stop = threading.Event()
+        self.write_lock = threading.Lock()
+        self.interval = keepalive_sec()
+        self._ka_thread: threading.Thread | None = None
+
+        self.message_id = f"msg_{uuid.uuid4().hex}"
+        self.reasoning_id = f"rs_{uuid.uuid4().hex}"
+        self.text = ""
+        self.reasoning = ""
+        self.tool_calls: list[Json] = []
+        self.usage: Json | None = None
+        self.got_data = False
+        self.item_open = False
+        self.reasoning_open = False
+        self.msg_index: int | None = None
+        self.reasoning_index = 0
+        self.next_output_index = 0
+        self._active_tool_index: int | None = None
+
+    # -- SSE write plumbing -------------------------------------------------
+
+    def _write(self, data: bytes) -> bool:
+        try:
+            with self.write_lock:
+                self.handler.wfile.write(data)
+                self.handler.wfile.flush()
+            return True
+        except (BrokenPipeError, OSError):
+            return False
+
+    def _keepalive(self) -> None:
+        while not self.keepalive_stop.wait(self.interval):
+            if not self.client_alive:
+                return
+            if not self._write(b": keepalive\n\n"):
+                self.client_alive = False
+                return
+
+    def _start_keepalive(self) -> None:
+        self._ka_thread = threading.Thread(target=self._keepalive, daemon=True)
+        self._ka_thread.start()
+
+    def _stop_keepalive(self) -> None:
+        self.keepalive_stop.set()
+
+    def send_event(self, event: Json) -> None:
+        if not self.client_alive:
+            return
+        data = b"data: " + json.dumps(event, separators=(",", ":")).encode("utf-8") + b"\n\n"
+        if not self._write(data):
+            self.client_alive = False
+            trace("client.disconnected", request_id=self.request_id, message="client closed connection during stream")
+
+    def send_error(self, message: str, *, code: str | None = None) -> None:
+        error: Json = {"message": message}
+        if code:
+            error["code"] = code
+        self.send_event({"type": "response.error", "error": error})
+        if self.client_alive:
+            self._write(b"data: [DONE]\n\n")
+
+    def allocate_index(self) -> int:
+        index = self.next_output_index
+        self.next_output_index += 1
+        return index
+
+    def _tokens(self) -> tuple[Any, Any, Any]:
+        """(input, output, total) from the accumulated usage object.
+
+        The chat family reports prompt/completion/total keys; anthropic and
+        gemini usage is normalized to input/output/total as it accumulates.
+        """
+        if self.family == "openai_chat":
+            return usage_tokens(self.usage)
+        if isinstance(self.usage, dict):
+            return (
+                self.usage.get("input_tokens"),
+                self.usage.get("output_tokens"),
+                self.usage.get("total_tokens"),
+            )
+        return None, None, None
+
+    def emit_reasoning(self, delta: str) -> None:
+        if not self.reasoning_open:
+            self.reasoning_index = self.allocate_index()
+            self.send_event(
+                {
+                    "type": "response.output_item.added",
+                    "output_index": self.reasoning_index,
+                    "item": {
+                        "type": "reasoning",
+                        "id": self.reasoning_id,
+                        "summary": [],
+                        "status": "in_progress",
+                    },
+                }
+            )
+            self.reasoning_open = True
+        self.reasoning += delta
+        self.send_event(
+            {
+                "type": "response.reasoning_summary_text.delta",
+                "item_id": self.reasoning_id,
+                "output_index": self.reasoning_index,
+                "summary_index": 0,
+                "delta": delta,
+            }
+        )
+
+    def emit_text(self, delta: str) -> None:
+        if not self.item_open:
+            self.msg_index = self.allocate_index()
+            self.send_event(
+                {
+                    "type": "response.output_item.added",
+                    "output_index": self.msg_index,
+                    "item": {
+                        "type": "message",
+                        "id": self.message_id,
+                        "role": "assistant",
+                        "status": "in_progress",
+                        "content": [],
+                    },
+                }
+            )
+            self.item_open = True
+        self.text += delta
+        self.send_event(
+            {
+                "type": "response.output_text.delta",
+                "item_id": self.message_id,
+                "output_index": self.msg_index,
+                "delta": delta,
+            }
+        )
+
+    # -- per-family chunk parsing -------------------------------------------
+
+    def handle_chunk(self, chunk: Json) -> None:
+        if self.family == "openai_chat":
+            self._handle_chat_chunk(chunk)
+        elif self.family == "anthropic_messages":
+            self._handle_anthropic_chunk(chunk)
+        else:
+            self._handle_gemini_chunk(chunk)
+
+    def _handle_chat_chunk(self, chunk: Json) -> None:
+        if chunk.get("usage"):
+            self.usage = chunk["usage"]
+        choices = chunk.get("choices") or []
+        if not choices or not isinstance(choices[0], dict):
+            return
+        delta = choices[0].get("delta") or {}
+        reasoning = delta.get("reasoning_content")
+        if isinstance(reasoning, str) and reasoning:
+            self.emit_reasoning(reasoning)
+        text = delta.get("content")
+        if isinstance(text, str) and text:
+            self.emit_text(text)
+        tool_calls = delta.get("tool_calls")
+        if isinstance(tool_calls, list):
+            for tool_call in tool_calls:
+                if not isinstance(tool_call, dict):
+                    continue
+                index = tool_call.get("index", 0)
+                while len(self.tool_calls) <= index:
+                    self.tool_calls.append({"id": "", "type": "function", "function": {"name": "", "arguments": ""}})
+                if tool_call.get("id"):
+                    self.tool_calls[index]["id"] = tool_call["id"]
+                function = tool_call.get("function") or {}
+                name_delta = function.get("name")
+                if name_delta:
+                    self.tool_calls[index]["function"]["name"] += name_delta
+                arguments_delta = function.get("arguments")
+                if arguments_delta:
+                    self.tool_calls[index]["function"]["arguments"] += arguments_delta
+
+    def _handle_anthropic_chunk(self, chunk: Json) -> None:
+        chunk_type = chunk.get("type")
+        if chunk_type == "message_start":
+            message = chunk.get("message")
+            usage = message.get("usage") if isinstance(message, dict) else None
+            if isinstance(usage, dict):
+                self.usage = _usage_to_openai_shape(usage)
+        elif chunk_type == "content_block_start":
+            block = chunk.get("content_block") or {}
+            if block.get("type") == "tool_use":
+                self._active_tool_index = len(self.tool_calls)
+                self.tool_calls.append(
+                    {
+                        "id": block.get("id") or f"call_{uuid.uuid4().hex}",
+                        "type": "function",
+                        "function": {"name": block.get("name", ""), "arguments": ""},
+                    }
+                )
+        elif chunk_type == "content_block_delta":
+            delta = chunk.get("delta") or {}
+            delta_type = delta.get("type")
+            if delta_type == "text_delta":
+                text = delta.get("text")
+                if isinstance(text, str) and text:
+                    self.emit_text(text)
+            elif delta_type == "input_json_delta":
+                partial = delta.get("partial_json")
+                index = self._active_tool_index
+                if isinstance(partial, str) and partial and index is not None and index < len(self.tool_calls):
+                    self.tool_calls[index]["function"]["arguments"] += partial
+        elif chunk_type == "message_delta":
+            usage = chunk.get("usage")
+            if isinstance(usage, dict) and usage.get("output_tokens") is not None:
+                self.usage = dict(self.usage or {})
+                self.usage["output_tokens"] = usage["output_tokens"]
+                inp = self.usage.get("input_tokens")
+                outp = usage["output_tokens"]
+                if isinstance(inp, int) and isinstance(outp, int):
+                    self.usage["total_tokens"] = inp + outp
+
+    def _handle_gemini_chunk(self, chunk: Json) -> None:
+        metadata = chunk.get("usageMetadata")
+        if isinstance(metadata, dict):
+            self.usage = {
+                "input_tokens": metadata.get("promptTokenCount"),
+                "output_tokens": metadata.get("candidatesTokenCount"),
+                "total_tokens": metadata.get("totalTokenCount"),
+            }
+        candidates = chunk.get("candidates") or []
+        if not candidates or not isinstance(candidates[0], dict):
+            return
+        content = candidates[0].get("content")
+        if not isinstance(content, dict):
+            return
+        for part in content.get("parts") or []:
+            if not isinstance(part, dict):
+                continue
+            text = part.get("text")
+            if isinstance(text, str) and text and not part.get("thought"):
+                self.emit_text(text)
+            function_call = part.get("functionCall")
+            if isinstance(function_call, dict):
+                self.tool_calls.append(
+                    {
+                        "id": f"call_{uuid.uuid4().hex}",
+                        "type": "function",
+                        "function": {
+                            "name": function_call.get("name", ""),
+                            "arguments": json.dumps(function_call.get("args") or {}, separators=(",", ":")),
+                        },
+                    }
+                )
+
+    # -- attempt lifecycle --------------------------------------------------
+
+    def _reset_accumulation(self) -> None:
+        self.text = ""
+        self.reasoning = ""
+        self.tool_calls = []
+        self.usage = None
+        self.got_data = False
+        self.item_open = False
+        self.reasoning_open = False
+        self.msg_index = None
+        self.next_output_index = 0
+        self._active_tool_index = None
+
+    def run_attempt(self, req: urllib.request.Request) -> str:
+        """Connect, stream, translate; returns 'content', 'empty', 'nodata', 'gone', or 'error'."""
+        try:
+            response, attempts = _open_upstream_stream(req, self.config, self.request_id, default_max_retries())
+            self.retries += attempts
+        except _ConnectFailed as fail:
+            self.retries += fail.attempts
+            exc = fail.exc
+            if isinstance(exc, urllib.error.HTTPError):
+                _relay_upstream_error(self.handler, exc.code, fail.body, exc.headers)
+                _meter_zen(self.model, self.started, exc.code, retries=self.retries or None)
+                return "error"
+            if isinstance(exc, TimeoutError):
+                _meter_zen(self.model, self.started, int(HTTPStatus.GATEWAY_TIMEOUT), retries=self.retries or None)
+                raise ProxyError(HTTPStatus.GATEWAY_TIMEOUT, "zen upstream timeout", retries=self.retries) from exc
+            _meter_zen(self.model, self.started, int(HTTPStatus.BAD_GATEWAY), retries=self.retries or None)
+            raise ProxyError(
+                HTTPStatus.BAD_GATEWAY,
+                f"zen upstream network error: {getattr(exc, 'reason', exc)}",
+                retries=self.retries,
+            ) from exc
+
+        try:
+            with response as resp:
+                for line in resp:
+                    if not self.client_alive:
+                        break
+                    line_text = line.decode("utf-8", errors="replace").strip()
+                    if not line_text.startswith("data: "):
+                        continue
+                    self.got_data = True
+                    data = line_text[6:]
+                    if data == "[DONE]":
+                        break
+                    try:
+                        chunk = json.loads(data)
+                    except json.JSONDecodeError:
+                        continue
+                    if isinstance(chunk, dict):
+                        self.handle_chunk(chunk)
+        except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError, OSError, http.client.HTTPException) as exc:
+            trace(
+                "zen.stream_aborted",
+                request_id=self.request_id,
+                status=exc.code if isinstance(exc, urllib.error.HTTPError) else getattr(exc, "reason", str(exc)),
+            )
+            self.send_error("zen upstream stream aborted")
+            _meter_zen(self.model, self.started, 502, stream_aborted=True, retries=self.retries or None)
+            return "error"
+
+        if not self.client_alive:
+            trace("zen.client_gone", request_id=self.request_id, message="client disconnected before final events")
+            _meter_zen(self.model, self.started, 0, stream_aborted=True, retries=self.retries or None)
+            return "gone"
+        if not self.got_data:
+            self.send_error("zen upstream returned no SSE data")
+            _meter_zen(self.model, self.started, 502, retries=self.retries or None)
+            return "nodata"
+        if not self.text and not self.tool_calls and not self.reasoning:
+            return "empty"
+        self.finalize()
+        return "content"
+
+    def finalize(self) -> None:
+        fake: Json = {}
+        if self.reasoning:
+            fake["reasoning_content"] = self.reasoning
+        if self.tool_calls:
+            fake["tool_calls"] = self.tool_calls
+        if self.text:
+            fake["content"] = self.text
+        output = chat_message_to_response_output(fake)
+
+        if self.reasoning_open:
+            reasoning_done: Json = {
+                "type": "reasoning",
+                "id": self.reasoning_id,
+                "summary": [{"type": "summary_text", "text": self.reasoning}],
+                "status": "completed",
+            }
+            self.send_event(
+                {"type": "response.output_item.done", "output_index": self.reasoning_index, "item": reasoning_done}
+            )
+            for out_item in output:
+                if out_item.get("type") == "reasoning":
+                    out_item["id"] = self.reasoning_id
+
+        tool_index = 0
+        for item in output:
+            if item.get("type") != "function_call":
+                continue
+            index = self.allocate_index()
+            self.send_event({"type": "response.output_item.added", "output_index": index, "item": item})
+            self.send_event({"type": "response.output_item.done", "output_index": index, "item": item})
+            tool_index += 1
+
+        if self.item_open and self.msg_index is not None:
+            message_done: Json = {
+                "type": "message",
+                "id": self.message_id,
+                "role": "assistant",
+                "status": "completed",
+                "content": [{"type": "output_text", "text": self.text, "annotations": []}],
+            }
+            self.send_event({"type": "response.output_item.done", "output_index": self.msg_index, "item": message_done})
+            for out_item in output:
+                if out_item.get("type") == "message":
+                    out_item["id"] = self.message_id
+
+        inp, outp, total = self._tokens()
+        if isinstance(inp, int) and inp > 0:
+            note_real_input_tokens(self.model)
+        context_cap = model_context_window(self.model) or DEFAULT_ESTIMATE_CONTEXT_WINDOW
+        estimated = estimate_input_tokens(self.model, len(self.raw_payload), self.usage, context_window=context_cap)
+        final: Json = {
+            "id": self.response_id,
+            "object": "response",
+            "created_at": now_unix(),
+            "status": "completed",
+            "model": self.model,
+            "output": output,
+            "output_text": self.text,
+            "usage": normalize_usage(self.usage, estimated_input_tokens=estimated),
+        }
+        self.send_event({"type": "response.completed", "response": final})
+        self._write(b"data: [DONE]\n\n")
+        if self.family == "openai_chat":
+            record_cache(self.config.cache_tracker, self.bare_id, self.usage)
+        _meter_zen(
+            self.model, self.started, 200,
+            input_tokens=inp, output_tokens=outp, total_tokens=total,
+            estimated_input_tokens=estimated,
+            retries=self.retries or None,
+        )
+        trace(
+            "zen.done", request_id=self.request_id, family=self.family, stream=True,
+            output_items=len(output), output_text_len=len(self.text),
+        )
+
+    def run(self, req: urllib.request.Request) -> None:
+        self.send_event(
+            {
+                "type": "response.created",
+                "response": {
+                    "id": self.response_id,
+                    "object": "response",
+                    "created_at": now_unix(),
+                    "status": "in_progress",
+                    "model": self.model,
+                    "output": [],
+                    "output_text": "",
+                    "usage": None,
+                },
+            }
+        )
+        empty_attempts = 0
+        while True:
+            outcome = self.run_attempt(req)
+            if outcome in ("error", "gone", "nodata"):
+                return
+            if outcome == "empty":
+                empty_attempts += 1
+                if empty_attempts == 1:
+                    # A streamed 200 with no output is retried once with the
+                    # identical request; response and item ids are reused.
+                    self._reset_accumulation()
+                    try:
+                        _response, more = _open_upstream_stream(req, self.config, self.request_id, default_max_retries())
+                        self.retries += more
+                    except _ConnectFailed as fail:
+                        self.retries += fail.attempts
+                        exc = fail.exc
+                        if isinstance(exc, urllib.error.HTTPError):
+                            _relay_upstream_error(self.handler, exc.code, fail.body, exc.headers)
+                            _meter_zen(self.model, self.started, exc.code, retries=self.retries or None)
+                            return
+                        if isinstance(exc, TimeoutError):
+                            _meter_zen(self.model, self.started, int(HTTPStatus.GATEWAY_TIMEOUT), retries=self.retries or None)
+                            raise ProxyError(HTTPStatus.GATEWAY_TIMEOUT, "zen upstream timeout", retries=self.retries) from exc
+                        _meter_zen(self.model, self.started, int(HTTPStatus.BAD_GATEWAY), retries=self.retries or None)
+                        raise ProxyError(
+                            HTTPStatus.BAD_GATEWAY,
+                            f"zen upstream network error: {getattr(exc, 'reason', exc)}",
+                            retries=self.retries,
+                        ) from exc
+                    continue
+                self.send_error("zen upstream returned an empty completion", code="empty_completion")
+                inp, outp, total = self._tokens()
+                if isinstance(inp, int) and inp > 0:
+                    note_real_input_tokens(self.model)
+                context_cap = model_context_window(self.model) or DEFAULT_ESTIMATE_CONTEXT_WINDOW
+                estimated = estimate_input_tokens(self.model, len(self.raw_payload), self.usage, context_window=context_cap)
+                _meter_zen(
+                    self.model, self.started, 200,
+                    input_tokens=inp, output_tokens=outp, total_tokens=total,
+                    estimated_input_tokens=estimated,
+                    empty_completion=True, retries=self.retries or None,
+                )
+                return
+            return
+
+
+def handle_zen_responses_request(handler: Any, payload: Json, config: ProxyConfig, request_id: str) -> None:
+    """Serve a /v1/responses request for a zen-routed model (stream and non-stream).
+
+    The zen path owns the whole HTTP response: connect-first, so an upstream
+    non-200 is answered with the upstream's own status and body before any SSE
+    is committed. Streaming is per-family translated back to Responses events;
+    the openai_responses family is relayed verbatim. Metering is provider="zen"
+    on every outcome (success, upstream error, network error, client gone).
+    """
+    started = time.time()
+    model = payload.get("model") or DEFAULT_MODEL
+    ensure_zen_slug(model)
+    bare_id = bare_zen_id(model)
+    family = zen_family_for(bare_id)
+
+    if payload.get("stream") is not True:
+        # call_zen_responses meters provider="zen" on success and on every
+        # ProxyError path, then re-raises for the dispatcher to render.
+        _send_json(handler, call_zen_responses(payload, config, request_id))
+        return
+
+    api_key = resolve_api_key(config, request_id)
+    url, body, headers = _build_zen_request(
+        payload, family, bare_id, api_key, stream=True, session_model=model
+    )
+    raw_payload = json.dumps(body, separators=(",", ":")).encode("utf-8")
+    req = urllib.request.Request(url, data=raw_payload, headers=headers, method="POST")
+    trace("zen.start", request_id=request_id, url=url, bytes=len(raw_payload), family=family, stream=True)
+    try:
+        response, retries = _open_upstream_stream(req, config, request_id, default_max_retries())
+    except _ConnectFailed as fail:
+        retries = fail.attempts
+        exc = fail.exc
+        if isinstance(exc, urllib.error.HTTPError):
+            _relay_upstream_error(handler, exc.code, fail.body, exc.headers)
+            _meter_zen(model, started, exc.code, retries=retries or None)
+            return
+        _meter_zen(
+            model, started,
+            int(HTTPStatus.GATEWAY_TIMEOUT if isinstance(exc, TimeoutError) else HTTPStatus.BAD_GATEWAY),
+            retries=retries or None,
+        )
+        if isinstance(exc, TimeoutError):
+            raise ProxyError(HTTPStatus.GATEWAY_TIMEOUT, "zen upstream timeout", retries=retries) from exc
+        raise ProxyError(HTTPStatus.BAD_GATEWAY, f"zen upstream network error: {getattr(exc, 'reason', exc)}", retries=retries) from exc
+
+    handler.send_response(HTTPStatus.OK)
+    handler.send_header("content-type", "text/event-stream")
+    handler.send_header("cache-control", "no-cache")
+    handler.end_headers()
+
+    if family == "openai_responses":
+        outcome = _relay_stream(response, handler, request_id)
+        if outcome == "done":
+            _meter_zen(model, started, 200, retries=retries or None)
+        elif outcome == "gone":
+            _meter_zen(model, started, 0, stream_aborted=True, retries=retries or None)
+        else:
+            _meter_zen(model, started, 502, stream_aborted=True, retries=retries or None)
+        trace("zen.done", request_id=request_id, family=family, stream=True, outcome=outcome)
+        return
+
+    engine = _ZenStreamEngine(
+        handler, payload, config, request_id,
+        family=family, bare_id=bare_id, model=model,
+        response_id=new_response_id(), started=started, raw_payload=raw_payload,
+    )
+    engine._start_keepalive()
+    try:
+        engine.run(req)
+    finally:
+        engine._stop_keepalive()
+
+
+def handle_zen_chat_request(handler: Any, payload: Json, config: ProxyConfig, request_id: str) -> None:
+    """Serve a /chat/completions request for a zen-routed model.
+
+    Verbatim relay to the zen chat-completions surface with the zen key and
+    base: the body, status, and stream are forwarded unchanged (only the model
+    prefix is stripped). The SSE head is committed only after the upstream
+    answers 200; non-200 upstream answers relay their own status and body.
+    """
+    started = time.time()
+    model = payload.get("model") or DEFAULT_MODEL
+    ensure_zen_slug(model)
+    bare_id = bare_zen_id(model)
+    api_key = resolve_api_key(config, request_id)
+    body = dict(payload)
+    body["model"] = bare_id
+    url = _zen_endpoint("openai_chat", bare_id, stream=payload.get("stream") is True)
+    raw_payload = json.dumps(body, separators=(",", ":")).encode("utf-8")
+    headers = _zen_headers("openai_chat", api_key, stream=payload.get("stream") is True)
+
+    if payload.get("stream") is True:
+        req = urllib.request.Request(url, data=raw_payload, headers=headers, method="POST")
+        trace("zen.start", request_id=request_id, url=url, bytes=len(raw_payload), family="openai_chat", stream=True)
+        try:
+            response, retries = _open_upstream_stream(req, config, request_id, default_max_retries())
+        except _ConnectFailed as fail:
+            retries = fail.attempts
+            exc = fail.exc
+            if isinstance(exc, urllib.error.HTTPError):
+                _relay_upstream_error(handler, exc.code, fail.body, exc.headers)
+                _meter_zen(model, started, exc.code, retries=retries or None)
+                return
+            _meter_zen(
+                model, started,
+                int(HTTPStatus.GATEWAY_TIMEOUT if isinstance(exc, TimeoutError) else HTTPStatus.BAD_GATEWAY),
+                retries=retries or None,
+            )
+            if isinstance(exc, TimeoutError):
+                raise ProxyError(HTTPStatus.GATEWAY_TIMEOUT, "zen upstream timeout", retries=retries) from exc
+            raise ProxyError(HTTPStatus.BAD_GATEWAY, f"zen upstream network error: {getattr(exc, 'reason', exc)}", retries=retries) from exc
+        handler.send_response(HTTPStatus.OK)
+        handler.send_header("content-type", "text/event-stream")
+        handler.send_header("cache-control", "no-cache")
+        handler.end_headers()
+        outcome = _relay_stream(response, handler, request_id)
+        if outcome == "done":
+            _meter_zen(model, started, 200, retries=retries or None)
+        elif outcome == "gone":
+            _meter_zen(model, started, 0, stream_aborted=True, retries=retries or None)
+        else:
+            _meter_zen(model, started, 502, stream_aborted=True, retries=retries or None)
+        trace("zen.done", request_id=request_id, family="openai_chat", stream=True, outcome=outcome)
+        return
+
+    status, raw, retries, content_type, retry_after = _zen_post_verbatim(
+        url, raw_payload, headers, config, request_id
+    )
+    _meter_zen(model, started, status, retries=retries or None)
+    handler.send_response(status)
+    if retry_after:
+        handler.send_header("retry-after", retry_after)
+    handler.send_header("content-type", content_type or "application/json")
+    handler.send_header("content-length", str(len(raw)))
+    handler.end_headers()
+    handler.wfile.write(raw)
+    handler.wfile.flush()

--- a/src/opencode_go_proxy/zen_upstream.py
+++ b/src/opencode_go_proxy/zen_upstream.py
@@ -1442,8 +1442,10 @@ class _ZenStreamEngine:
                     note_real_input_tokens(self.model)
                 context_cap = model_context_window(self.model) or DEFAULT_ESTIMATE_CONTEXT_WINDOW
                 estimated = estimate_input_tokens(self.model, len(self.raw_payload), self.usage, context_window=context_cap)
+                # The client-visible outcome is response.error empty_completion,
+                # so the meter records 502 (a failed turn), never a success.
                 _meter_zen(
-                    self.model, self.started, 200,
+                    self.model, self.started, 502,
                     input_tokens=inp, output_tokens=outp, total_tokens=total,
                     estimated_input_tokens=estimated,
                     empty_completion=True, retries=self.retries or None,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -266,5 +266,78 @@ class CaptionTimeoutTests(unittest.TestCase):
             self.assertEqual(_caption_timeout_sec(), 1.0)
 
 
+class CatalogRefreshTimerTests(unittest.TestCase):
+    """The background catalog refresh must also run on an interval; the timer
+    thread must be daemon (dies with the process) and quiet when refresh is
+    disabled via env. Asserted via monkeypatched Thread/sleep, never real
+    sleeps."""
+
+    def test_start_catalog_refresh_threads_are_daemon(self) -> None:
+        from opencode_go_proxy import app as proxy_app
+
+        with mock.patch.object(proxy_app.threading, "Thread") as thread_cls, mock.patch.dict(
+            os.environ, {}, clear=False
+        ):
+            os.environ.pop("OPENCODE_GO_CATALOG_REFRESH", None)
+            thread_cls.return_value = mock.Mock()
+            proxy_app._start_catalog_refresh()
+
+        self.assertTrue(all(call.kwargs.get("daemon") is True for call in thread_cls.call_args_list))
+        names = [call.kwargs["name"] for call in thread_cls.call_args_list]
+        self.assertIn("catalog-refresh", names)
+        self.assertIn("catalog-refresh-timer", names)
+
+    def test_start_catalog_refresh_skips_timer_when_disabled(self) -> None:
+        from opencode_go_proxy import app as proxy_app
+
+        with mock.patch.object(proxy_app.threading, "Thread") as thread_cls, mock.patch.dict(
+            os.environ, {"OPENCODE_GO_CATALOG_REFRESH": "0"}, clear=False
+        ):
+            thread_cls.return_value = mock.Mock()
+            proxy_app._start_catalog_refresh()
+
+        targets = [call.kwargs["target"] for call in thread_cls.call_args_list]
+        self.assertIn(proxy_app._refresh_catalog_in_background, targets)
+        self.assertNotIn(proxy_app._refresh_catalog_daemon, targets)
+
+    def test_refresh_daemon_loop_ticks_on_interval(self) -> None:
+        from opencode_go_proxy import app as proxy_app
+
+        sleeps: list[float] = []
+
+        def fake_sleep(seconds: float) -> None:
+            sleeps.append(seconds)
+            if len(sleeps) >= 2:
+                raise KeyboardInterrupt
+
+        with mock.patch.object(proxy_app.time, "sleep", side_effect=fake_sleep), mock.patch.object(
+            proxy_app, "_refresh_catalog_once"
+        ) as once, mock.patch.object(proxy_app, "trace") as traced, mock.patch.dict(
+            os.environ, {}, clear=False
+        ):
+            os.environ.pop("OPENCODE_GO_CATALOG_REFRESH", None)
+            with self.assertRaises(KeyboardInterrupt):
+                proxy_app._refresh_catalog_daemon(interval_hours=6)
+
+        # Each tick sleeps the full interval before refreshing; the second
+        # sleep raises, so exactly one refresh ran.
+        self.assertEqual(sleeps, [6 * 3600, 6 * 3600])
+        self.assertEqual(once.call_count, 1)
+        ticks = [c for c in traced.call_args_list if c.args[0] == "catalog.refresh.tick"]
+        self.assertEqual(len(ticks), 1)
+
+    def test_refresh_daemon_stays_quiet_when_disabled(self) -> None:
+        from opencode_go_proxy import app as proxy_app
+
+        with mock.patch.dict(
+            os.environ, {"OPENCODE_GO_CATALOG_REFRESH": "0"}, clear=False
+        ), mock.patch.object(proxy_app.time, "sleep", side_effect=KeyboardInterrupt), mock.patch.object(
+            proxy_app, "_refresh_catalog_once"
+        ) as once, self.assertRaises(KeyboardInterrupt):
+            proxy_app._refresh_catalog_daemon()
+
+        once.assert_not_called()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,4 +1,5 @@
 import json
+import os
 import tempfile
 import unittest
 import urllib.error
@@ -8,18 +9,21 @@ from unittest import mock
 
 from opencode_go_proxy.catalog import (
     CatalogDiscoveryError,
+    CatalogNotModified,
     _model_from_discovery,
     discover_models,
     load_known_slugs,
     merge_models,
+    merged_model_slugs,
     model_messages,
     render_full_catalog,
 )
 
 
 class FakeResponse:
-    def __init__(self, payload: dict) -> None:
+    def __init__(self, payload: dict, headers: dict | None = None) -> None:
         self._payload = payload
+        self.headers = headers or {}
 
     def __enter__(self) -> Self:
         return self
@@ -29,6 +33,14 @@ class FakeResponse:
 
     def read(self) -> bytes:
         return json.dumps(self._payload).encode()
+
+
+def _request_header(request, name: str) -> str | None:
+    """Case-insensitive header lookup; urllib capitalizes header keys."""
+    return next(
+        (value for key, value in request.header_items() if key.lower() == name.lower()),
+        None,
+    )
 
 
 class DiscoverModelsTests(unittest.TestCase):
@@ -55,10 +67,11 @@ class DiscoverModelsTests(unittest.TestCase):
         def capture(request, *args, **kwargs):
             seen["url"] = request.full_url
             seen["ua"] = request.headers.get("User-agent")
-            return FakeResponse(payload)
+            seen["if_none_match"] = _request_header(request, "If-None-Match")
+            return FakeResponse(payload, headers={"ETag": 'W/"models-dev-v42"'})
 
         with mock.patch("opencode_go_proxy.catalog.urllib.request.urlopen", side_effect=capture):
-            models = discover_models()
+            models, etag = discover_models()
 
         self.assertEqual([m["id"] for m in models], ["gpt-5.5", "deepseek-v4-flash"])
         self.assertNotIn("some-model", {m["id"] for m in models})
@@ -66,6 +79,25 @@ class DiscoverModelsTests(unittest.TestCase):
         # fetch must carry an identifying UA.
         self.assertEqual(seen["url"], "https://models.dev/api.json")
         self.assertTrue(seen["ua"].startswith("opencode-go-proxy/"))
+        # No stored etag on a first fetch: no conditional header is sent, and
+        # the response ETag flows back for the caller to store.
+        self.assertIsNone(seen["if_none_match"])
+        self.assertEqual(etag, 'W/"models-dev-v42"')
+
+    def test_discover_models_sends_if_none_match_and_raises_on_304(self) -> None:
+        seen: dict = {}
+
+        def capture(request, *args, **kwargs):
+            seen["if_none_match"] = _request_header(request, "If-None-Match")
+            raise urllib.error.HTTPError(request.full_url, 304, "Not Modified", {}, None)
+
+        with mock.patch(
+            "opencode_go_proxy.catalog.urllib.request.urlopen", side_effect=capture
+        ), self.assertRaises(CatalogNotModified) as ctx:
+            discover_models(etag='W/"abc"')
+
+        self.assertEqual(seen["if_none_match"], 'W/"abc"')
+        self.assertEqual(ctx.exception.etag, 'W/"abc"')
 
     def test_discover_models_raises_on_urlopen_failure(self) -> None:
         with mock.patch(
@@ -99,6 +131,52 @@ class MergeModelsTests(unittest.TestCase):
 
         self.assertEqual([m["id"] for m in new_models], ["brand-new"])
         self.assertEqual(removed, ["old-known"])
+
+
+class MergedModelSlugsTests(unittest.TestCase):
+    """The menu bar polls /v1/models every 3s; the mtime memo must make that
+    one stat per poll and re-read only when the merged file actually changes."""
+
+    def _write_merged(self, path: str, slugs: list[str]) -> None:
+        with open(path, "w") as f:
+            json.dump({"etag": "x", "models": [{"slug": s} for s in slugs]}, f)
+
+    def test_memo_serves_cache_and_rereads_on_mtime_change(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "merged-models.json")
+            with mock.patch("opencode_go_proxy.catalog.merged_models_path", return_value=path):
+                # Missing file: empty result, cached under mtime None.
+                self.assertEqual(merged_model_slugs(), [])
+                # A new file has a new mtime: re-read.
+                self._write_merged(path, ["a", "b"])
+                self.assertEqual(merged_model_slugs(), ["a", "b"])
+                # Same content rewritten at the SAME mtime: served from the
+                # cache (no re-read), so the poll stays a single stat.
+                st = os.stat(path)
+                self._write_merged(path, ["a", "b", "c"])
+                os.utime(path, ns=(st.st_atime_ns, st.st_mtime_ns))
+                self.assertEqual(merged_model_slugs(), ["a", "b"])
+                # Touching the mtime invalidates the memo: re-read.
+                os.utime(path, ns=(st.st_atime_ns, st.st_mtime_ns + 1))
+                self.assertEqual(merged_model_slugs(), ["a", "b", "c"])
+                # Removing the file flips mtime back to None: re-read to empty.
+                os.unlink(path)
+                self.assertEqual(merged_model_slugs(), [])
+
+    def test_memo_keys_on_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            first = os.path.join(tmp, "one.json")
+            second = os.path.join(tmp, "two.json")
+            self._write_merged(first, ["a"])
+            self._write_merged(second, ["z"])
+            with mock.patch("opencode_go_proxy.catalog.merged_models_path", return_value=first):
+                self.assertEqual(merged_model_slugs(), ["a"])
+            # A different merged file is a different cache slot.
+            with mock.patch("opencode_go_proxy.catalog.merged_models_path", return_value=second):
+                self.assertEqual(merged_model_slugs(), ["z"])
+            # Back to the first file: served from its slot without re-reading.
+            with mock.patch("opencode_go_proxy.catalog.merged_models_path", return_value=first):
+                self.assertEqual(merged_model_slugs(), ["a"])
 
 
 class LoadKnownSlugsTests(unittest.TestCase):

--- a/tests/test_catalog_local.py
+++ b/tests/test_catalog_local.py
@@ -165,10 +165,12 @@ class TestAnnouncements:
         )
 
         new = {m["slug"]: m for m in out}["brand-new"]
-        assert new["availability_nux"] == (
-            "Brand New just landed in your model picker. It comes with a 400K-token "
-            "context window, reasoning efforts from low to max, and image input."
-        )
+        assert new["availability_nux"] == {
+            "message": (
+                "Brand New just landed in your model picker. It comes with a 400K-token "
+                "context window, reasoning efforts from low to max, and image input."
+            )
+        }
         assert next_announced["brand-new"] == 1_000_100.0
 
     def test_curated_models_never_announce(self) -> None:

--- a/tests/test_catalog_local.py
+++ b/tests/test_catalog_local.py
@@ -225,7 +225,7 @@ class TestRuntimeRefresh:
         with open("contrib/opencode-go-catalog.json") as fh:
             contrib_catalog = fh.read()
 
-        with mock.patch("opencode_go_proxy.catalog.discover_models", return_value=[]):
+        with mock.patch("opencode_go_proxy.catalog.discover_models", return_value=([], None)):
             catalog.refresh_runtime_catalog()
 
         with open("contrib/opencode-go-models.json") as fh:
@@ -251,7 +251,7 @@ class TestRuntimeRefresh:
                 },
                 f,
             )
-        with mock.patch("opencode_go_proxy.catalog.discover_models", return_value=[]):
+        with mock.patch("opencode_go_proxy.catalog.discover_models", return_value=([], None)):
             catalog.refresh_runtime_catalog()
 
         # No explicit reload call: the mtime cache must pick the change up.
@@ -325,7 +325,7 @@ def test_models_endpoint_grows_after_refresh_without_restart(proxy_server) -> No
             },
             f,
         )
-    with mock.patch("opencode_go_proxy.catalog.discover_models", return_value=[]):
+    with mock.patch("opencode_go_proxy.catalog.discover_models", return_value=([], None)):
         catalog.refresh_runtime_catalog()
 
     after = set(_list_models(port))

--- a/tests/test_catalog_refresh.py
+++ b/tests/test_catalog_refresh.py
@@ -1,8 +1,10 @@
 import datetime
 import json
 import os
+import re
 import tempfile
 import unittest
+import urllib.error
 from unittest import mock
 
 from opencode_go_proxy.catalog import (
@@ -10,6 +12,29 @@ from opencode_go_proxy.catalog import (
     _model_from_discovery,
     refresh_catalog,
 )
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict, headers: dict | None = None) -> None:
+        self._payload = payload
+        self.headers = headers or {}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return json.dumps(self._payload).encode()
+
+
+def _request_header(request, name: str) -> str | None:
+    """Case-insensitive header lookup; urllib capitalizes header keys."""
+    return next(
+        (value for key, value in request.header_items() if key.lower() == name.lower()),
+        None,
+    )
 
 
 def make_compact(fetched_at: str) -> dict:
@@ -96,7 +121,7 @@ class RefreshCatalogTests(unittest.TestCase):
             }
         ]
 
-        with mock.patch("opencode_go_proxy.catalog.discover_models", return_value=discovered):
+        with mock.patch("opencode_go_proxy.catalog.discover_models", return_value=(discovered, None)):
             rendered = refresh_catalog(
                 compact_path=self.compact_path,
                 catalog_path=self.catalog_path,
@@ -112,7 +137,7 @@ class RefreshCatalogTests(unittest.TestCase):
     def test_force_refreshes_fresh_compact(self) -> None:
         self._write_compact((self.now - datetime.timedelta(hours=1)).isoformat())
 
-        with mock.patch("opencode_go_proxy.catalog.discover_models", return_value=[]):
+        with mock.patch("opencode_go_proxy.catalog.discover_models", return_value=([], None)):
             rendered = refresh_catalog(
                 compact_path=self.compact_path,
                 catalog_path=self.catalog_path,
@@ -182,6 +207,144 @@ class RefreshCatalogTests(unittest.TestCase):
             )
         self.assertEqual(rendered["models"][0]["slug"], "existing-model")
         self.assertTrue(os.path.exists(self.catalog_path))
+
+    def test_etag_is_stored_and_sent_as_if_none_match_on_next_refresh(self) -> None:
+        self._write_compact((self.now - datetime.timedelta(hours=25)).isoformat())
+        state = {"sent_etag": None, "respond_304": False}
+
+        def fake_urlopen(request, *args, **kwargs):
+            state["sent_etag"] = _request_header(request, "If-None-Match")
+            if state["respond_304"]:
+                raise urllib.error.HTTPError(request.full_url, 304, "Not Modified", {}, None)
+            return _FakeResponse(
+                {"opencode": {"models": {"existing-model": {"id": "existing-model", "name": "Existing Model"}}}},
+                headers={"ETag": 'W/"models-dev-v7"'},
+            )
+
+        with mock.patch("opencode_go_proxy.catalog.urllib.request.urlopen", side_effect=fake_urlopen):
+            rendered = refresh_catalog(
+                compact_path=self.compact_path,
+                catalog_path=self.catalog_path,
+                now=self.now,
+            )
+        with open(self.compact_path) as f:
+            compact = json.load(f)
+        # The models.dev ETag is stored in the compact (and rendered) meta.
+        self.assertEqual(compact["etag"], 'W/"models-dev-v7"')
+        self.assertEqual(rendered["etag"], 'W/"models-dev-v7"')
+        # The fixture compact already carries an etag, so even the first fetch
+        # is conditional on it.
+        self.assertEqual(state["sent_etag"], 'W/"opencode-go-models-test"')
+
+        # Compact stale again: the stored etag must be sent as If-None-Match.
+        later = self.now + datetime.timedelta(hours=25)
+        state["respond_304"] = True
+        with mock.patch("opencode_go_proxy.catalog.urllib.request.urlopen", side_effect=fake_urlopen):
+            refresh_catalog(
+                compact_path=self.compact_path,
+                catalog_path=self.catalog_path,
+                now=later,
+            )
+        self.assertEqual(state["sent_etag"], 'W/"models-dev-v7"')
+
+    def test_304_keeps_compact_and_skips_render(self) -> None:
+        self._write_compact((self.now - datetime.timedelta(hours=25)).isoformat())
+        state = {"respond_304": False}
+
+        def fake_urlopen(request, *args, **kwargs):
+            if state["respond_304"]:
+                raise urllib.error.HTTPError(request.full_url, 304, "Not Modified", {}, None)
+            return _FakeResponse(
+                {"opencode": {"models": {"existing-model": {"id": "existing-model", "name": "Existing Model"}}}},
+                headers={"ETag": 'W/"models-dev-v9"'},
+            )
+
+        with mock.patch("opencode_go_proxy.catalog.urllib.request.urlopen", side_effect=fake_urlopen):
+            refresh_catalog(
+                compact_path=self.compact_path,
+                catalog_path=self.catalog_path,
+                now=self.now,
+            )
+        compact_mtime = os.path.getmtime(self.compact_path)
+        catalog_mtime = os.path.getmtime(self.catalog_path)
+        with open(self.compact_path) as f:
+            compact_before = f.read()
+        with open(self.catalog_path) as f:
+            catalog_before = f.read()
+
+        state["respond_304"] = True
+        later = self.now + datetime.timedelta(hours=25)
+        with mock.patch("opencode_go_proxy.catalog.urllib.request.urlopen", side_effect=fake_urlopen), mock.patch(
+            "opencode_go_proxy.catalog.trace"
+        ) as traced:
+            rendered = refresh_catalog(
+                compact_path=self.compact_path,
+                catalog_path=self.catalog_path,
+                now=later,
+            )
+
+        # 304 means unchanged: neither file is rewritten, the returned catalog
+        # is the one already on disk, and a cached-refresh event is traced.
+        self.assertEqual(os.path.getmtime(self.compact_path), compact_mtime)
+        self.assertEqual(os.path.getmtime(self.catalog_path), catalog_mtime)
+        with open(self.compact_path) as f:
+            self.assertEqual(f.read(), compact_before)
+        with open(self.catalog_path) as f:
+            self.assertEqual(f.read(), catalog_before)
+        self.assertEqual(rendered["etag"], 'W/"models-dev-v9"')
+        cached = [c for c in traced.call_args_list if c.args[0] == "catalog.refresh.cached"]
+        self.assertEqual(len(cached), 1)
+
+    def test_etag_stable_across_refreshes_with_identical_content(self) -> None:
+        # No server ETag header: the content-hash fallback must be identical
+        # across refreshes of the same model set (the old daily synthetic etag
+        # churned the Codex client cache even when nothing changed).
+
+        def fake_urlopen(request, *args, **kwargs):
+            return _FakeResponse(
+                {"opencode": {"models": {"existing-model": {"id": "existing-model", "name": "Existing Model"}}}}
+            )
+
+        with mock.patch("opencode_go_proxy.catalog.urllib.request.urlopen", side_effect=fake_urlopen):
+            refresh_catalog(
+                compact_path=self.compact_path,
+                catalog_path=self.catalog_path,
+                now=self.now,
+            )
+        with open(self.compact_path) as f:
+            first = json.load(f)
+
+        later = self.now + datetime.timedelta(hours=25)
+        with mock.patch("opencode_go_proxy.catalog.urllib.request.urlopen", side_effect=fake_urlopen):
+            refresh_catalog(
+                compact_path=self.compact_path,
+                catalog_path=self.catalog_path,
+                now=later,
+            )
+        with open(self.compact_path) as f:
+            second = json.load(f)
+
+        self.assertEqual(first["etag"], second["etag"])
+        self.assertIsNotNone(re.fullmatch(r'W/"[0-9a-f]{32}"', first["etag"]))
+
+    def test_force_refresh_skips_conditional_get(self) -> None:
+        self._write_compact((self.now - datetime.timedelta(hours=1)).isoformat())
+        seen = {}
+
+        def fake_urlopen(request, *args, **kwargs):
+            seen["if_none_match"] = _request_header(request, "If-None-Match")
+            return _FakeResponse({"opencode": {"models": {}}})
+
+        with mock.patch("opencode_go_proxy.catalog.urllib.request.urlopen", side_effect=fake_urlopen):
+            refresh_catalog(
+                compact_path=self.compact_path,
+                catalog_path=self.catalog_path,
+                now=self.now,
+                force=True,
+            )
+
+        # A forced refresh wants a fresh copy: never a conditional GET.
+        self.assertIsNone(seen["if_none_match"])
 
     def test_model_from_discovery_maps_fields(self) -> None:
         record = _model_from_discovery(

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -1,0 +1,634 @@
+"""Remote-compaction support: v1 /responses/compact and v2 trigger-item turns.
+
+Every test drives the real proxy HTTP surface (in-process server on a scratch
+port) against an http.server mock upstream that records the requests it sees,
+then verifies the client-visible response, the usage-meter row, and the mock's
+request log. Offline and deterministic: all traffic is loopback, the state dir
+is a per-test tmp dir (conftest), and the keys are never printed.
+"""
+
+import json
+import os
+import socket
+import threading
+import time
+from collections.abc import Generator
+from http.client import HTTPConnection, HTTPResponse
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from unittest import mock
+
+import pytest
+
+from opencode_go_proxy import compaction
+from opencode_go_proxy.app import ProxyConfig, ResponsesProxyHandler
+from opencode_go_proxy.meter import usage_events_path
+from opencode_go_proxy.secrets import clear_api_key_cache
+from opencode_go_proxy.usage_poller import clear_cache as clear_usage_poller_cache
+
+SCRATCH_PORT_PREFERRED = 8795
+PROXY_TIMEOUT_SEC = 2.0
+MODEL = "deepseek-v4-flash"
+ZEN_MODEL = "zen/deepseek-v4-flash"
+SUMMARY_TEXT = "The user asked to wire the widget to the backend; decision: REST over gRPC; open question: retry policy."
+ZEN_SUMMARY_TEXT = "Zen handoff summary: migrate the catalog render, keep the compact seed."
+
+MODE_OK = "ok"
+MODE_500 = "500"
+
+GO_PATH = "/chat/completions"
+ZEN_PATH_PREFIX = "/zen/"
+
+
+class RequestRecord:
+    """What the mock saw for one upstream request (auth value kept in memory only)."""
+
+    def __init__(self, path: str, headers: dict[str, str], raw_body: bytes) -> None:
+        self.path = path
+        self.headers = {name.lower(): value for name, value in headers.items()}
+        self.content_type = self.headers.get("content-type", "")
+        self.has_authorization = "authorization" in self.headers
+        self.raw_body = raw_body
+
+    @property
+    def json_body(self) -> dict:
+        return json.loads(self.raw_body)
+
+
+class ScriptedUpstream:
+    """One scripted persona: records every request, then answers per `mode`."""
+
+    def __init__(self, mode: str = MODE_OK) -> None:
+        self.mode = mode
+        self.requests: list[RequestRecord] = []
+
+    def record(self, path: str, headers: dict[str, str], raw_body: bytes) -> None:
+        self.requests.append(RequestRecord(path, headers, raw_body))
+
+    @property
+    def count(self) -> int:
+        return len(self.requests)
+
+    def reset_log(self) -> None:
+        self.requests.clear()
+
+    def handle(self, handler: BaseHTTPRequestHandler) -> None:
+        if self.mode == MODE_500:
+            self._send_json(
+                handler,
+                500,
+                {"error": {"type": "server_error", "message": "boom"}},
+            )
+            return
+        self._send_json(
+            handler,
+            200,
+            {
+                "id": "chatcmpl-compact",
+                "object": "chat.completion",
+                "model": MODEL,
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": SUMMARY_TEXT},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {"prompt_tokens": 11, "completion_tokens": 7, "total_tokens": 18},
+            },
+        )
+
+    def _send_json(self, handler: BaseHTTPRequestHandler, status: int, payload: dict) -> None:
+        raw = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        handler.send_response(status)
+        handler.send_header("content-type", "application/json")
+        handler.send_header("content-length", str(len(raw)))
+        handler.end_headers()
+        handler.wfile.write(raw)
+
+
+class MockUpstreamHandler(BaseHTTPRequestHandler):
+    """HTTP surface for the scripted upstream; every request is recorded.
+
+    Serves both surfaces: the opencode-go chat-completions endpoint and the
+    zen surface under ``/zen/`` (same chat-completion wire shape for the
+    openai_chat family the tests use).
+    """
+
+    protocol_version = "HTTP/1.0"
+    server_version = "MockUpstream/1.0"
+
+    def log_message(self, message_format: str, *args: object) -> None:
+        return
+
+    def do_POST(self) -> None:
+        length = int(self.headers.get("content-length") or "0")
+        raw_body = self.rfile.read(length) if length else b""
+        self.server.behavior.record(self.path, dict(self.headers), raw_body)
+        try:
+            self.server.behavior.handle(self)
+        except (BrokenPipeError, ConnectionResetError):
+            pass
+
+
+class _MockServer(ThreadingHTTPServer):
+    daemon_threads = True
+    behavior: ScriptedUpstream
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.behavior = ScriptedUpstream(MODE_OK)
+
+
+class _ScratchProxyServer(ThreadingHTTPServer):
+    daemon_threads = True
+    config: ProxyConfig
+
+
+def _wait_for_listener(port: int, timeout_sec: float = 5.0) -> None:
+    deadline = time.monotonic() + timeout_sec
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.2):
+                return
+        except OSError:
+            time.sleep(0.01)
+    raise AssertionError(f"port {port} never accepted connections")
+
+
+def _pick_scratch_port() -> int:
+    candidates = [SCRATCH_PORT_PREFERRED, *range(SCRATCH_PORT_PREFERRED + 1, SCRATCH_PORT_PREFERRED + 8)]
+    for port in candidates:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+            try:
+                probe.bind(("127.0.0.1", port))
+                return port
+            except OSError:
+                continue
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.bind(("127.0.0.1", 0))
+        return probe.getsockname()[1]
+
+
+@pytest.fixture
+def scratch_port() -> Generator[int, None, None]:
+    yield _pick_scratch_port()
+
+
+@pytest.fixture
+def mock_upstream() -> Generator[_MockServer, None, None]:
+    server = _MockServer(("127.0.0.1", 0), MockUpstreamHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    _wait_for_listener(server.server_address[1])
+    yield server
+    server.shutdown()
+    server.server_close()
+
+
+@pytest.fixture
+def proxy_env(mock_upstream: _MockServer) -> Generator[str, None, None]:
+    """Isolated env for the scratch proxy: fast retries, zen pointed at the mock."""
+    base_url = f"http://127.0.0.1:{mock_upstream.server_address[1]}"
+    with mock.patch.dict(
+        os.environ,
+        {
+            "OPENCODE_GO_API_KEY": "",
+            "OPENCODE_API_KEY": "",
+            "OPENCODE_GO_PROXY_RETRY_BASE_MS": "1",
+            "OPENCODE_GO_PROXY_MAX_RETRIES": "2",
+            "OPENCODE_ZEN_BASE_URL": f"{base_url}/zen/v1",
+            "HTTP_PROXY": "",
+            "HTTPS_PROXY": "",
+            "ALL_PROXY": "",
+            "http_proxy": "",
+            "https_proxy": "",
+            "all_proxy": "",
+            "SSL_CERT_FILE": "",
+            "SSL_CERT_DIR": "",
+            "NO_PROXY": "*",
+            "no_proxy": "*",
+        }
+    ):
+        clear_api_key_cache()
+        clear_usage_poller_cache()
+        yield base_url
+
+
+@pytest.fixture
+def proxy(proxy_env: str, scratch_port: int) -> Generator[_ScratchProxyServer, None, None]:
+    server = _ScratchProxyServer(("127.0.0.1", scratch_port), ResponsesProxyHandler)
+    server.config = ProxyConfig(
+        bind="127.0.0.1",
+        port=scratch_port,
+        chat_base_url=proxy_env,
+        api_key_env="OPENCODE_GO_API_KEY",
+        timeout_sec=PROXY_TIMEOUT_SEC,
+        max_body_bytes=20 * 1024 * 1024,
+    )
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    _wait_for_listener(scratch_port)
+    yield server
+    server.shutdown()
+    server.server_close()
+
+
+def http_request(
+    port: int,
+    method: str,
+    path: str,
+    *,
+    body: bytes | None = None,
+    headers: dict[str, str] | None = None,
+    timeout_sec: float = 15.0,
+) -> tuple[int, dict[str, str], bytes]:
+    conn = HTTPConnection("127.0.0.1", port, timeout=timeout_sec)
+    try:
+        conn.request(method, path, body, headers or {})
+        response = conn.getresponse()
+        raw = response.read()
+        status = response.status
+        response_headers = {name.lower(): value for name, value in response.getheaders()}
+        return status, response_headers, raw
+    finally:
+        conn.close()
+
+
+def post_json(port: int, path: str, payload: dict) -> tuple[int, dict[str, str], bytes]:
+    raw = json.dumps(payload).encode("utf-8")
+    return http_request(port, "POST", path, body=raw, headers={"content-type": "application/json"})
+
+
+def open_stream(
+    port: int, path: str, payload: dict, *, timeout_sec: float = 15.0
+) -> tuple[HTTPConnection, HTTPResponse]:
+    conn = HTTPConnection("127.0.0.1", port, timeout=timeout_sec)
+    conn.request("POST", path, json.dumps(payload).encode("utf-8"), {"content-type": "application/json"})
+    response = conn.getresponse()
+    return conn, response
+
+
+def read_until(response: HTTPResponse, marker: bytes, *, timeout_sec: float = 15.0) -> bytes:
+    accumulated = bytearray()
+    deadline = time.monotonic() + timeout_sec
+    while marker not in accumulated:
+        if time.monotonic() > deadline:
+            raise AssertionError(f"stream did not reach {marker!r} within {timeout_sec}s")
+        chunk = response.read1(8192)
+        if not chunk:
+            break
+        accumulated.extend(chunk)
+    return bytes(accumulated)
+
+
+def meter_events() -> list[dict]:
+    try:
+        with open(usage_events_path(), encoding="utf-8") as handle:
+            return [json.loads(line) for line in handle if line.strip()]
+    except OSError:
+        return []
+
+
+def sse_events(raw: bytes) -> list[dict]:
+    """Parse the proxy's ``event:`` + ``data:`` SSE frames into event dicts."""
+    events: list[dict] = []
+    current: dict | None = None
+    for line in raw.decode("utf-8", errors="replace").splitlines():
+        if line.startswith("data: "):
+            payload = line[len("data: "):]
+            if payload == "[DONE]":
+                continue
+            event = json.loads(payload)
+            current = event
+        elif line == "" and current is not None:
+            events.append(current)
+            current = None
+    if current is not None:
+        events.append(current)
+    return events
+
+
+def message_item(role: str, text: str) -> dict:
+    return {"type": "message", "role": role, "content": [{"type": "input_text", "text": text}]}
+
+
+def conversation_input(*texts: str) -> list[dict]:
+    return [message_item("user", text) for text in texts]
+
+
+# ---------------------------------------------------------------------------
+# Unit-level contracts (no server)
+# ---------------------------------------------------------------------------
+
+
+def test_encode_decode_summary_round_trip() -> None:
+    encoded = compaction.encode_summary(SUMMARY_TEXT)
+    assert encoded.startswith("kcr1:")
+    assert compaction.decode_summary(encoded) == SUMMARY_TEXT
+    # Decoder refuses foreign or malformed payloads instead of crashing.
+    assert compaction.decode_summary("not-ours") is None
+    assert compaction.decode_summary("kcr1:%%%") is None
+    assert compaction.decode_summary(None) is None
+
+
+def test_has_compaction_trigger_last_item_only() -> None:
+    trigger = {"type": "context_compaction", "id": "cmp_x"}
+    assert compaction.has_compaction_trigger({"input": [message_item("user", "hi"), trigger]})
+    assert compaction.has_compaction_trigger({"input": [{"type": "compaction_trigger"}]})
+    # A history that merely CONTAINS a compaction item is a normal turn.
+    assert not compaction.has_compaction_trigger(
+        {"input": [message_item("user", "hi"), trigger, message_item("user", "latest")]}
+    )
+    assert not compaction.has_compaction_trigger({"input": "plain string"})
+    assert not compaction.has_compaction_trigger({"input": []})
+    assert not compaction.has_compaction_trigger({"input": None})
+
+
+def test_render_transcript_skips_trigger_and_bounds_to_tail() -> None:
+    input_items = conversation_input("A" * 10, "B" * 10) + [{"type": "compaction_trigger"}]
+    transcript = compaction.render_transcript(input_items, budget=12)
+    # Tail-most 12 chars: the join plus the last message ("B"*10).
+    assert transcript.endswith("B" * 10)
+    assert "A" not in transcript
+    assert compaction.render_transcript(
+        conversation_input("x", "y"), budget=100
+    ) == "x\n\ny"
+
+
+# ---------------------------------------------------------------------------
+# v1: dedicated /responses/compact endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_v1_compact_returns_compaction_item_with_decodable_summary(
+    proxy: _ScratchProxyServer, mock_upstream: _MockServer, scratch_port: int
+) -> None:
+    payload = {"model": MODEL, "input": conversation_input("hello", "build the widget")}
+    status, headers, raw = post_json(scratch_port, "/responses/compact", payload)
+    assert status == 200, raw
+    assert headers.get("content-type", "").startswith("application/json")
+    body = json.loads(raw)
+    assert body["object"] == "response"
+    assert body["status"] == "completed"
+    assert body["model"] == MODEL
+    assert len(body["output"]) == 1
+    item = body["output"][0]
+    assert item["type"] == "compaction"
+    assert item["id"].startswith("cmp_")
+    assert compaction.decode_summary(item["encrypted_content"]) == SUMMARY_TEXT
+
+    # One summarization sub-call against the opencode-go chat surface, non-stream.
+    assert mock_upstream.behavior.count == 1
+    request = mock_upstream.behavior.requests[0]
+    assert request.path == GO_PATH
+    chat = request.json_body
+    assert chat.get("stream") is False
+    assert chat["model"] == MODEL  # bare slug, not the opencode-go prefix
+    assert chat["messages"][1]["content"] == compaction.COMPACT_PROMPT
+    assert chat["messages"][0]["content"] == "hello\n\nbuild the widget"
+
+    events = meter_events()
+    assert len(events) == 1
+    assert events[0]["status"] == 200
+    assert events[0]["model"] == MODEL
+    assert events[0]["provider"] == "opencode-go"
+    assert events[0]["inputTokens"] == 11
+    assert events[0]["outputTokens"] == 7
+    assert events[0]["totalTokens"] == 18
+
+
+def test_v1_compact_via_v1_prefix_path(
+    proxy: _ScratchProxyServer, mock_upstream: _MockServer, scratch_port: int
+) -> None:
+    payload = {"model": MODEL, "input": "prefix works"}
+    status, _headers, raw = post_json(scratch_port, "/v1/responses/compact", payload)
+    assert status == 200, raw
+    body = json.loads(raw)
+    assert body["output"][0]["type"] == "compaction"
+    assert compaction.decode_summary(body["output"][0]["encrypted_content"]) == SUMMARY_TEXT
+    assert mock_upstream.behavior.count == 1
+
+
+# ---------------------------------------------------------------------------
+# v2: trigger-item detection on the responses path
+# ---------------------------------------------------------------------------
+
+
+def test_v2_context_compaction_trigger_streams_expected_sse_sequence(
+    proxy: _ScratchProxyServer, mock_upstream: _MockServer, scratch_port: int
+) -> None:
+    payload = {
+        "model": MODEL,
+        "stream": True,
+        "input": conversation_input("earlier", "now") + [{"type": "context_compaction", "id": "cmp_42"}],
+    }
+    conn, response = open_stream(scratch_port, "/v1/responses", payload)
+    try:
+        assert response.status == 200
+        assert response.getheader("content-type", "") == "text/event-stream"
+        raw = read_until(response, b"[DONE]")
+    finally:
+        conn.close()
+    events = sse_events(raw)
+    assert [event["type"] for event in events] == [
+        "response.created",
+        "response.output_item.added",
+        "response.output_item.done",
+        "response.completed",
+    ]
+    assert [event.get("sequence_number") for event in events] == [0, 1, 2, 3]
+    added = events[1]
+    assert added["output_index"] == 0
+    item = added["item"]
+    assert item["type"] == "context_compaction"
+    assert item["id"].startswith("cmp_")
+    assert compaction.decode_summary(item["encrypted_content"]) == SUMMARY_TEXT
+    assert events[3]["response"]["status"] == "completed"
+    assert events[3]["response"]["output"] == [item]
+
+    # The trigger item never reaches the summarization call, and the turn
+    # metered once as a 200 opencode-go turn.
+    chat = mock_upstream.behavior.requests[0].json_body
+    transcript = chat["messages"][0]["content"]
+    assert "compaction_trigger" not in transcript
+    assert "context_compaction" not in transcript
+    assert "earlier\n\nnow" == transcript
+    events_log = meter_events()
+    assert len(events_log) == 1
+    assert events_log[0]["status"] == 200
+    assert events_log[0]["provider"] == "opencode-go"
+
+
+def test_v2_compaction_trigger_type_also_detected(
+    proxy: _ScratchProxyServer, mock_upstream: _MockServer, scratch_port: int
+) -> None:
+    payload = {
+        "model": MODEL,
+        "stream": True,
+        "input": conversation_input("history") + [{"type": "compaction_trigger"}],
+    }
+    conn, response = open_stream(scratch_port, "/v1/responses", payload)
+    try:
+        raw = read_until(response, b"[DONE]")
+    finally:
+        conn.close()
+    events = sse_events(raw)
+    assert [event["type"] for event in events][:2] == ["response.created", "response.output_item.added"]
+    assert events[1]["item"]["type"] == "context_compaction"
+    assert mock_upstream.behavior.count == 1
+
+
+def test_v2_non_stream_returns_json_shape(
+    proxy: _ScratchProxyServer, mock_upstream: _MockServer, scratch_port: int
+) -> None:
+    payload = {
+        "model": MODEL,
+        "stream": False,
+        "input": conversation_input("quiet") + [{"type": "context_compaction", "id": "cmp_7"}],
+    }
+    status, _headers, raw = post_json(scratch_port, "/v1/responses", payload)
+    assert status == 200, raw
+    body = json.loads(raw)
+    assert body["status"] == "completed"
+    assert body["output"][0]["type"] == "context_compaction"
+    assert compaction.decode_summary(body["output"][0]["encrypted_content"]) == SUMMARY_TEXT
+
+
+# ---------------------------------------------------------------------------
+# Pass-through regressions: the compaction branch must not hijack normal turns
+# ---------------------------------------------------------------------------
+
+
+def test_normal_responses_passes_through_unchanged(
+    proxy: _ScratchProxyServer, mock_upstream: _MockServer, scratch_port: int
+) -> None:
+    payload = {"model": MODEL, "input": conversation_input("say something")}
+    status, _headers, raw = post_json(scratch_port, "/v1/responses", payload)
+    assert status == 200, raw
+    body = json.loads(raw)
+    assert body["status"] == "completed"
+    output = body["output"]
+    assert len(output) == 1
+    assert output[0]["type"] == "message"
+    assert output[0]["content"][0]["text"] == SUMMARY_TEXT
+    # The normal path still produced one ordinary chat-completions call.
+    assert mock_upstream.behavior.count == 1
+    assert mock_upstream.behavior.requests[0].path == GO_PATH
+
+
+def test_post_compaction_history_is_not_hijacked(
+    proxy: _ScratchProxyServer, mock_upstream: _MockServer, scratch_port: int
+) -> None:
+    # After a v2 compaction the app replays the compaction item inside the
+    # history; the current user message stays last, so this must NOT be
+    # treated as another compaction request.
+    payload = {
+        "model": MODEL,
+        "input": [
+            message_item("user", "before"),
+            {"type": "context_compaction", "id": "cmp_old", "encrypted_content": compaction.encode_summary("old")},
+            message_item("user", "latest question"),
+        ],
+    }
+    status, _headers, raw = post_json(scratch_port, "/v1/responses", payload)
+    assert status == 200, raw
+    body = json.loads(raw)
+    assert body["status"] == "completed"
+    assert all(item["type"] != "context_compaction" and item["type"] != "compaction" for item in body["output"])
+    assert body["output"][0]["content"][0]["text"] == SUMMARY_TEXT
+    assert mock_upstream.behavior.count == 1
+
+
+def test_malformed_payload_falls_through_to_normal_path(
+    proxy: _ScratchProxyServer, mock_upstream: _MockServer, scratch_port: int
+) -> None:
+    # A malformed trigger-shaped payload must not crash the dispatcher; it
+    # takes the normal path.
+    payload = {"model": MODEL, "input": "plain string"}
+    status, _headers, raw = post_json(scratch_port, "/v1/responses", payload)
+    assert status == 200, raw
+    body = json.loads(raw)
+    assert body["output"][0]["content"][0]["text"] == SUMMARY_TEXT
+    assert mock_upstream.behavior.count == 1
+
+
+# ---------------------------------------------------------------------------
+# Summarization input contract + failure metering
+# ---------------------------------------------------------------------------
+
+
+def test_summarization_prompt_keeps_transcript_tail_and_drops_trigger(
+    proxy: _ScratchProxyServer, mock_upstream: _MockServer, scratch_port: int
+) -> None:
+    head = "A" * 40_000
+    middle = "B" * 40_000
+    tail = "C" * 40_000
+    payload = {
+        "model": MODEL,
+        "input": conversation_input(head, middle, tail) + [{"type": "compaction_trigger"}],
+    }
+    status, _headers, raw = post_json(scratch_port, "/v1/responses", payload)
+    assert status == 200, raw
+    chat = mock_upstream.behavior.requests[0].json_body
+    messages = chat["messages"]
+    assert len(messages) == 2
+    transcript = messages[0]["content"]
+    assert messages[1]["content"] == compaction.COMPACT_PROMPT
+    # Budget keeps the most recent 80k chars: the whole tail message, none of
+    # the head, and no trigger-item residue.
+    assert len(transcript) <= 80_000
+    assert transcript.endswith("C" * 40_000)
+    assert "A" not in transcript
+    assert "compaction_trigger" not in transcript
+
+
+def test_upstream_failure_surfaces_error_and_meters(
+    proxy: _ScratchProxyServer, mock_upstream: _MockServer, scratch_port: int
+) -> None:
+    mock_upstream.behavior.mode = MODE_500
+    payload = {"model": MODEL, "input": conversation_input("try")}
+    status, _headers, raw = post_json(scratch_port, "/responses/compact", payload)
+    assert status == 502, raw
+    body = json.loads(raw)
+    assert body["error"]["type"] == "proxy_error"
+    assert "upstream HTTP 500" in body["error"]["message"]
+    # Initial attempt + 2 retries.
+    assert mock_upstream.behavior.count == 3
+    events = meter_events()
+    assert len(events) == 1
+    assert events[0]["status"] == 502
+    assert events[0]["retries"] == 2
+    assert events[0]["model"] == MODEL
+
+
+# ---------------------------------------------------------------------------
+# Zen routing: provider="zen" meter row, zen upstream surface
+# ---------------------------------------------------------------------------
+
+
+def test_zen_compaction_routes_through_zen_upstream(
+    proxy: _ScratchProxyServer, mock_upstream: _MockServer, scratch_port: int
+) -> None:
+    mock_upstream.behavior = ScriptedUpstream(MODE_OK)
+    payload = {"model": ZEN_MODEL, "input": conversation_input("zen session")}
+    status, _headers, raw = post_json(scratch_port, "/responses/compact", payload)
+    assert status == 200, raw
+    body = json.loads(raw)
+    assert body["output"][0]["type"] == "compaction"
+    assert compaction.decode_summary(body["output"][0]["encrypted_content"]) == SUMMARY_TEXT
+    # The zen surface (openai_chat family) received exactly one call.
+    assert mock_upstream.behavior.count == 1
+    request = mock_upstream.behavior.requests[0]
+    assert request.path == f"{ZEN_PATH_PREFIX}v1/chat/completions"
+    chat = request.json_body
+    assert chat["stream"] is False
+    assert chat["model"] == "deepseek-v4-flash"  # bare zen id on the wire
+    assert chat["messages"][1]["content"] == compaction.COMPACT_PROMPT
+    events = meter_events()
+    assert len(events) == 1
+    assert events[0]["status"] == 200
+    assert events[0]["provider"] == "zen"
+    assert events[0]["model"] == ZEN_MODEL
+    assert events[0]["inputTokens"] == 11
+    assert events[0]["outputTokens"] == 7
+    assert events[0]["totalTokens"] == 18

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -187,12 +187,18 @@ def mock_upstream() -> Generator[_MockServer, None, None]:
 
 @pytest.fixture
 def proxy_env(mock_upstream: _MockServer) -> Generator[str, None, None]:
-    """Isolated env for the scratch proxy: fast retries, zen pointed at the mock."""
+    """Scratch-proxy env: explicit fake key, fast retries, zen at the mock.
+
+    OPENCODE_GO_API_KEY is set to a literal fake key so key resolution is
+    deterministic and never consults the ambient env or the macOS keychain
+    (CI has neither). OPENCODE_API_KEY is pinned empty so an inherited
+    standard key cannot leak in either.
+    """
     base_url = f"http://127.0.0.1:{mock_upstream.server_address[1]}"
     with mock.patch.dict(
         os.environ,
         {
-            "OPENCODE_GO_API_KEY": "",
+            "OPENCODE_GO_API_KEY": "test-key",
             "OPENCODE_API_KEY": "",
             "OPENCODE_GO_PROXY_RETRY_BASE_MS": "1",
             "OPENCODE_GO_PROXY_MAX_RETRIES": "2",

--- a/tests/test_config_edge_matrix.py
+++ b/tests/test_config_edge_matrix.py
@@ -267,15 +267,13 @@ class TestBackupGate:
         before = _read(cfg_path)
         config_manager.enable()
         directory = os.path.dirname(cfg_path)
-        candidates = [
+        prefix = os.path.basename(cfg_path) + ".bak-"
+        backups = sorted(
             name
             for name in os.listdir(directory)
-            if name != os.path.basename(cfg_path) and os.path.isfile(os.path.join(directory, name))
-        ]
-        assert candidates, (
-            "no backup file written before enable() modified config.toml "
-            "(GATE: backup written before edits)"
+            if name.startswith(prefix) and os.path.isfile(os.path.join(directory, name))
         )
-        assert any(
-            _read(os.path.join(directory, name)) == before for name in candidates
-        ), f"backup files {candidates!r} do not contain the pre-edit content"
+        assert len(backups) == 1, f"expected exactly one backup, got {backups!r}"
+        backup_path = os.path.join(directory, backups[0])
+        assert _read(backup_path) == before, "backup must hold the pre-edit content byte-for-byte"
+        assert (os.stat(backup_path).st_mode & 0o777) == 0o600, "backup must keep mode 0600"

--- a/tests/test_config_edge_matrix.py
+++ b/tests/test_config_edge_matrix.py
@@ -1,0 +1,281 @@
+"""Config-manager edge matrix: enable/disable/status across key ownership.
+
+Extends tests/test_config_manager.py with the four provider-key ownership
+combinations (no user keys, user owns the opencode-go key, user owns the zen
+key, user owns both), the idempotency guarantees, TOML validity, marker
+boundaries, provider-table preservation, and the backup-before-edit gate.
+
+Every test is fully hermetic: the config path, state dir (catalog render),
+and codex binary all live under tmp_path; the real ~/.codex/config.toml and
+the real codex binary are never touched.
+"""
+
+import json
+import os
+import tomllib
+
+import pytest
+
+from opencode_go_proxy import config_manager
+
+# A user-declared provider table "owns" a key: the managed block must omit the
+# table entirely (TOML forbids splitting one table across two locations) and
+# must leave the user's fields byte-for-byte intact.
+USER_OP = (
+    "[model_providers.opencode-go]\n"
+    'name = "OpenCode Go (user)"\n'
+    'base_url = "https://user.example/v1"\n'
+    'env_key = "OPENCODE_GO_API_KEY"\n'
+    'wire_api = "responses"\n'
+)
+USER_ZEN = (
+    "[model_providers.zen]\n"
+    'name = "Zen (user)"\n'
+    'base_url = "https://user.example/zen/v1"\n'
+    'env_key = "OPENCODE_ZEN_API_KEY"\n'
+    'wire_api = "responses"\n'
+)
+
+
+@pytest.fixture
+def cfg_path(tmp_path, monkeypatch) -> str:
+    """Temp config.toml plus an isolated state dir for the catalog render."""
+    path = str(tmp_path / "config.toml")
+    monkeypatch.setenv("OPENCODE_GO_PROXY_CONFIG_PATH", path)
+    monkeypatch.setenv("OPENCODE_GO_PROXY_STATE_DIR", str(tmp_path / "state"))
+    return path
+
+
+@pytest.fixture(autouse=True)
+def fake_codex_bin(tmp_path, monkeypatch) -> str:
+    """Point OPENCODE_GO_PROXY_CODEX_BIN at a script that accepts multi_agent_v2."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    codex = bin_dir / "codex"
+    codex.write_text("#!/bin/sh\nexit 0\n")
+    codex.chmod(0o755)
+    monkeypatch.setenv("OPENCODE_GO_PROXY_CODEX_BIN", str(codex))
+    return str(codex)
+
+
+def _read(path: str) -> str:
+    with open(path, encoding="utf-8") as handle:
+        return handle.read()
+
+
+def _block_text(text: str) -> str:
+    """The managed marker block, START marker through END marker inclusive."""
+    start = text.index(config_manager.START_MARKER)
+    end = text.index(config_manager.END_MARKER)
+    return text[start : end + len(config_manager.END_MARKER)]
+
+
+def _write(path: str, contents: str) -> None:
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(contents)
+
+
+def _assert_managed_block(block: str) -> None:
+    """Marker boundaries: exactly one BEGIN/END pair, END last in the block."""
+    assert block.startswith(config_manager.START_MARKER)
+    assert block.rstrip().endswith(config_manager.END_MARKER)
+    assert block.count(config_manager.START_MARKER) == 1
+    assert block.count(config_manager.END_MARKER) == 1
+
+
+def _assert_provider_table(block: str, name: str, *, present: bool) -> None:
+    """A managed provider table renders name/base_url/wire_api exactly once."""
+    header = f"[model_providers.{name}]"
+    if present:
+        assert header in block
+        table = block.split(header, 1)[1]
+        assert f'name = "{name}"' in table
+        assert f"base_url = {json.dumps(config_manager.managed_base_url())}" in table
+        assert 'wire_api = "responses"' in table
+    else:
+        assert header not in block
+
+
+@pytest.mark.parametrize(
+    ("user_config", "managed_op", "managed_zen"),
+    [
+        pytest.param("", True, True, id="no-user-keys"),
+        pytest.param(USER_OP, False, True, id="user-owns-opencode-go"),
+        pytest.param(USER_ZEN, True, False, id="user-owns-zen"),
+        pytest.param(USER_OP + "\n" + USER_ZEN, False, False, id="user-owns-both"),
+    ],
+)
+class TestEnableMatrix:
+    def test_enable_renders_valid_toml_with_correct_blocks(
+        self, cfg_path, user_config: str, managed_op: bool, managed_zen: bool
+    ) -> None:
+        if user_config:
+            _write(cfg_path, user_config)
+        report = config_manager.enable()
+        assert report["changed"] is True
+        text = _read(cfg_path)
+        data = tomllib.loads(text)
+        block = _block_text(text)
+
+        _assert_managed_block(block)
+        _assert_provider_table(block, "opencode-go", present=managed_op)
+        _assert_provider_table(block, "zen", present=managed_zen)
+
+        # Root wiring the managed block owns.
+        assert data["openai_base_url"] == config_manager.managed_base_url()
+        assert data["model_catalog_json"] == config_manager.managed_catalog_path()
+        assert (
+            f"model_catalog_json = {json.dumps(config_manager.managed_catalog_path())}" in block
+        )
+        assert config_manager.REALTIME_CALL_KEY in block
+        assert config_manager.REALTIME_WS_KEY in block
+        assert data[config_manager.REALTIME_WS_KEY] == config_manager.DEFAULT_REALTIME_WS_BASE_URL
+
+        # multi_agent_v2 probe passes and the user does not configure it: the
+        # managed feature block is present and parses.
+        assert "[features.multi_agent_v2]" in block
+        assert data["features"]["multi_agent_v2"]["enabled"] is True
+
+        # Whatever the ownership state, exactly one table per provider parses.
+        providers = data["model_providers"]
+        assert set(providers) == {"opencode-go", "zen"}
+        assert text.count("[model_providers.opencode-go]") == 1
+        assert text.count("[model_providers.zen]") == 1
+
+    def test_enable_twice_is_byte_idempotent(
+        self, cfg_path, user_config: str, managed_op: bool, managed_zen: bool
+    ) -> None:
+        del managed_op, managed_zen
+        if user_config:
+            _write(cfg_path, user_config)
+        config_manager.enable()
+        first = _read(cfg_path)
+        report = config_manager.enable()
+        assert report["changed"] is False
+        assert _read(cfg_path) == first
+        assert _read(cfg_path).count(config_manager.START_MARKER) == 1
+        assert _read(cfg_path).count(config_manager.END_MARKER) == 1
+
+    def test_status_reports_provider_blocks_per_ownership(
+        self, cfg_path, user_config: str, managed_op: bool, managed_zen: bool
+    ) -> None:
+        if user_config:
+            _write(cfg_path, user_config)
+        config_manager.enable()
+        report = config_manager.status()
+        assert report["state"] == "enabled"
+        assert report["managed"] is True
+        assert report["provider_block"] is managed_op
+        assert report["zen_provider_block"] is managed_zen
+        assert set(report["voice_keys_managed"]) == {
+            config_manager.REALTIME_CALL_KEY,
+            config_manager.REALTIME_WS_KEY,
+        }
+        assert report["voice_keys_user_owned"] == []
+        config_manager.disable()
+        after = config_manager.status()
+        assert after["state"] == "disabled"
+        assert after["provider_block"] is False
+        assert after["zen_provider_block"] is False
+
+
+class TestDisableEdge:
+    def test_disable_removes_both_blocks_and_keeps_user_content(self, cfg_path) -> None:
+        user = (
+            'model = "gpt-5.6-luna"\n'
+            'model_provider = "opencode-go"\n'
+            "\n"
+            + USER_OP
+            + "\n"
+            + USER_ZEN
+        )
+        _write(cfg_path, user)
+        config_manager.enable()
+        assert tomllib.loads(_read(cfg_path))["model_providers"]
+        assert config_manager.disable()["changed"] is True
+        text = _read(cfg_path)
+        assert config_manager.START_MARKER not in text
+        assert config_manager.END_MARKER not in text
+        assert text == user
+        assert tomllib.loads(text)["model_providers"]  # user tables still parse
+
+    def test_disable_keeps_content_when_user_root_adjacent_to_table(self, cfg_path) -> None:
+        """Semantic preservation when the user wrote root keys flush against a
+        table header: the renderer inserts a blank separator (cosmetic), so
+        bytes differ but the parsed config is identical.
+        """
+        user = 'model = "gpt-5.6-luna"\n' + USER_OP
+        _write(cfg_path, user)
+        config_manager.enable()
+        config_manager.disable()
+        text = _read(cfg_path)
+        assert tomllib.loads(text) == tomllib.loads(user)
+        assert config_manager.START_MARKER not in text
+
+    def test_disable_twice_is_byte_idempotent(self, cfg_path) -> None:
+        _write(cfg_path, 'model = "gpt-5.6-luna"\n')
+        config_manager.enable()
+        config_manager.disable()
+        first = _read(cfg_path)
+        report = config_manager.disable()
+        assert report["changed"] is False
+        assert _read(cfg_path) == first
+
+    def test_enable_disable_round_trip_restores_provider_tables(self, cfg_path) -> None:
+        user = USER_OP + "\n" + USER_ZEN
+        _write(cfg_path, user)
+        config_manager.enable()
+        assert "[model_providers.opencode-go]" in _read(cfg_path)
+        config_manager.disable()
+        assert _read(cfg_path) == user
+
+
+class TestUserProviderPreservation:
+    def test_user_table_never_duplicated_or_clobbered(self, cfg_path) -> None:
+        """Documented behavior: the managed table is omitted, not merged."""
+        _write(cfg_path, USER_OP)
+        config_manager.enable()
+        text = _read(cfg_path)
+        assert tomllib.loads(text)["model_providers"]["opencode-go"]["name"] == "OpenCode Go (user)"
+        assert text.count("[model_providers.opencode-go]") == 1
+        user_section = text.split("[model_providers.opencode-go]", 1)[1]
+        assert 'name = "OpenCode Go (user)"' in user_section
+        assert 'env_key = "OPENCODE_GO_API_KEY"' in user_section
+        assert "8787" not in user_section
+        # The managed block sits before the user table and owns the zen side.
+        block = _block_text(text)
+        assert "[model_providers.opencode-go]" not in block
+        assert "[model_providers.zen]" in block
+        assert text.index(config_manager.END_MARKER) < text.index("[model_providers.opencode-go]")
+
+    def test_user_multi_agent_v2_configuration_preserved(self, cfg_path) -> None:
+        user = "multi_agent_v2 = { enabled = true, num_agents = 3 }\n"
+        _write(cfg_path, user)
+        config_manager.enable()
+        text = _read(cfg_path)
+        data = tomllib.loads(text)
+        assert data["multi_agent_v2"] == {"enabled": True, "num_agents": 3}
+        assert "[features.multi_agent_v2]" not in text
+        assert text.startswith(user)
+
+
+class TestBackupGate:
+    def test_backup_written_before_modification(self, cfg_path) -> None:
+        """GATE (GATES.md config gate): a backup holds the pre-edit content."""
+        user = 'model = "gpt-5.6-luna"\n' + USER_ZEN
+        _write(cfg_path, user)
+        before = _read(cfg_path)
+        config_manager.enable()
+        directory = os.path.dirname(cfg_path)
+        candidates = [
+            name
+            for name in os.listdir(directory)
+            if name != os.path.basename(cfg_path) and os.path.isfile(os.path.join(directory, name))
+        ]
+        assert candidates, (
+            "no backup file written before enable() modified config.toml "
+            "(GATE: backup written before edits)"
+        )
+        assert any(
+            _read(os.path.join(directory, name)) == before for name in candidates
+        ), f"backup files {candidates!r} do not contain the pre-edit content"

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -266,6 +266,54 @@ class TestCli:
         assert "refusing to replace" in capsys.readouterr().err
 
 
+class TestZenProviderBlock:
+    def test_zen_block_rendered_next_to_opencode_go(self, cfg_path) -> None:
+        config_manager.enable()
+        text = _read(cfg_path)
+        assert "[model_providers.opencode-go]" in text
+        assert "[model_providers.zen]" in text
+        assert 'name = "zen"' in text
+        assert f"base_url = {json.dumps(config_manager.managed_base_url())}" in text
+        assert 'wire_api = "responses"' in text
+        assert text.index("[model_providers.opencode-go]") > text.index(config_manager.START_MARKER)
+        assert text.index("[model_providers.zen]") > text.index(config_manager.START_MARKER)
+        assert text.index(config_manager.END_MARKER) > text.index("[model_providers.zen]")
+
+    def test_omits_zen_block_when_user_owns_zen_keys(self, cfg_path) -> None:
+        user = '[model_providers.zen]\nbase_url = "https://user.example/v1"\nwire_api = "responses"\n'
+        with open(cfg_path, "w", encoding="utf-8") as handle:
+            handle.write(user)
+        config_manager.enable()
+        text = _read(cfg_path)
+        assert text.count("[model_providers.zen]") == 1
+        zen_section = text.split("[model_providers.zen]", 1)[1]
+        assert 'base_url = "https://user.example/v1"' in zen_section
+        assert "8787" not in zen_section
+        assert "[model_providers.opencode-go]" in text
+
+    def test_enable_disable_round_trip_removes_both_blocks(self, cfg_path) -> None:
+        with open(cfg_path, "w", encoding="utf-8") as handle:
+            handle.write('model = "gpt-5.6-luna"\n')
+        config_manager.enable()
+        text = _read(cfg_path)
+        assert "[model_providers.opencode-go]" in text
+        assert "[model_providers.zen]" in text
+        config_manager.disable()
+        text = _read(cfg_path)
+        assert "[model_providers.opencode-go]" not in text
+        assert "[model_providers.zen]" not in text
+        assert text == 'model = "gpt-5.6-luna"\n'
+
+    def test_status_reports_zen_block(self, cfg_path) -> None:
+        config_manager.enable()
+        report = config_manager.status()
+        assert report["provider_block"] is True
+        assert report["zen_provider_block"] is True
+        config_manager.disable()
+        report = config_manager.status()
+        assert report["zen_provider_block"] is False
+
+
 class TestNoDuplicateKeys:
     def test_enable_with_matching_user_values_has_no_duplicate_keys(self, tmp_path, fake_codex_bin) -> None:
         path = tmp_path / "config.toml"

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -379,3 +379,26 @@ class TestBackup:
         backups = _backup_names(directory, cfg_path)
         assert len(backups) == 1
         assert _read(os.path.join(directory, backups[-1])) == enabled_text
+
+    def test_backup_failure_raises_before_mutation(self, cfg_path, monkeypatch) -> None:
+        """A failed backup write must abort enable() before config.toml changes.
+
+        The backup lands via _atomic_write on a config.toml.bak-* path; when
+        that write fails, the error propagates before the main write, so the
+        config file stays byte-for-byte unchanged and no backup is left behind.
+        """
+        with open(cfg_path, "w", encoding="utf-8") as handle:
+            handle.write('model = "gpt-5.6-luna"\n')
+        before = _read(cfg_path)
+        real_replace = os.replace
+
+        def failing_replace(src: str, dst: str) -> None:
+            if ".bak-" in os.path.basename(str(dst)):
+                raise OSError("backup write failed")
+            real_replace(src, dst)
+
+        monkeypatch.setattr(os, "replace", failing_replace)
+        with pytest.raises(OSError, match="backup write failed"):
+            config_manager.enable()
+        assert _read(cfg_path) == before
+        assert _backup_names(os.path.dirname(cfg_path), cfg_path) == []

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -339,3 +339,43 @@ class TestNoDuplicateKeys:
         assert text.count("openai_base_url") == 1
         assert text.count("model_catalog_json") == 1
         assert config_manager.START_MARKER in text
+
+
+def _backup_names(directory: str, cfg_path: str) -> list[str]:
+    prefix = os.path.basename(cfg_path) + ".bak-"
+    return sorted(name for name in os.listdir(directory) if name.startswith(prefix))
+
+
+class TestBackup:
+    def test_second_enable_without_change_writes_no_second_backup(self, cfg_path) -> None:
+        """A no-op enable() (already enabled) must not write another backup."""
+        with open(cfg_path, "w", encoding="utf-8") as handle:
+            handle.write('model = "gpt-5.6-luna"\n')
+        config_manager.enable()
+        directory = os.path.dirname(cfg_path)
+        backups = _backup_names(directory, cfg_path)
+        assert len(backups) == 1
+        assert config_manager.enable()["changed"] is False
+        assert _backup_names(directory, cfg_path) == backups
+
+    def test_disable_writes_backup_before_removing_block(self, cfg_path) -> None:
+        """disable() snapshots the managed config before rewriting it."""
+        with open(cfg_path, "w", encoding="utf-8") as handle:
+            handle.write('model = "gpt-5.6-luna"\n')
+        config_manager.enable()
+        enabled_text = _read(cfg_path)
+        assert config_manager.disable()["changed"] is True
+        directory = os.path.dirname(cfg_path)
+        backups = _backup_names(directory, cfg_path)
+        assert len(backups) == 2
+        assert _read(os.path.join(directory, backups[-1])) == enabled_text
+
+    def test_disable_file_removal_still_backs_up(self, cfg_path) -> None:
+        """Removing the file (block was its only content) still snapshots it."""
+        config_manager.enable()  # file was absent, so enable writes no backup
+        enabled_text = _read(cfg_path)
+        assert config_manager.disable()["file_removed"] is True
+        directory = os.path.dirname(cfg_path)
+        backups = _backup_names(directory, cfg_path)
+        assert len(backups) == 1
+        assert _read(os.path.join(directory, backups[-1])) == enabled_text

--- a/tests/test_correctness.py
+++ b/tests/test_correctness.py
@@ -148,7 +148,9 @@ class TestEmptyCompletionRetry:
         assert not any(e["type"] == "response.completed" for e in events)
         assert b"[DONE]" in wfile.getvalue()
         assert len(meter) == 1
-        assert meter[0]["status"] == 200
+        # The client-visible outcome is a response.error, so the turn meters
+        # as a failed 502, never a success.
+        assert meter[0]["status"] == 502
         assert meter[0]["emptyCompletion"] is True
         assert meter[0]["retries"] == 1
 

--- a/tests/test_failure_matrix.py
+++ b/tests/test_failure_matrix.py
@@ -415,13 +415,17 @@ def read_until(response: HTTPResponse, marker: bytes, *, timeout_sec: float = 15
 def read_until_then_disconnect(
     conn: HTTPConnection, response: HTTPResponse, marker: bytes, *, timeout_sec: float = 15.0
 ) -> bytes:
-    """Read until `marker`, then close the connection as a client cancel would.
+    """Read until `marker`, then cancel the stream as a real client would.
 
-    A graceful FIN is used, not an RST: on macOS a peer RST is only reported
-    through recv, while sends after a FIN-then-RST fail with EPIPE, which is
-    the write failure the proxy's disconnect detection watches for.
+    The response must be closed, not just the connection: HTTPConnection.close()
+    only marks the socket closed in Python while the response's buffered reader
+    keeps the FD open, so the peer would never see a FIN/RST and the proxy's
+    liveness peek could not detect the cancel. Closing the response sends the
+    FIN (or RST with unread data) that the peek reads as the client-gone
+    signal the meter must record as status 0.
     """
     accumulated = read_until(response, marker, timeout_sec=timeout_sec)
+    response.close()
     conn.close()
     return accumulated
 

--- a/tests/test_failure_matrix.py
+++ b/tests/test_failure_matrix.py
@@ -1,0 +1,750 @@
+"""Failure-mode matrix: proxy reliability contracts against a scripted mock upstream.
+
+Every scenario drives the real proxy HTTP surface (in-process server on the
+scratch port 8792) against an http.server mock upstream scripted per scenario,
+then verifies the client-visible response, the usage-meter row, and the mock's
+request log. Offline and deterministic: all traffic is loopback, the state dir
+is a per-test tmp dir, and the key env is cleared so key resolution walks to
+the macOS keychain (the resolved value never appears in test output) or fails
+for the keyless scenario.
+
+Contract expectations come from the reliability spec; where the current code
+behaves differently the scenario FAILS and reports the mismatch with evidence
+instead of silently adjusting the expectation.
+"""
+
+import json
+import os
+import socket
+import struct
+import subprocess
+import threading
+import time
+from collections.abc import Callable, Generator
+from http.client import HTTPConnection, HTTPResponse
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from unittest import mock
+
+import pytest
+
+from opencode_go_proxy import catalog
+from opencode_go_proxy.app import ProxyConfig, ResponsesProxyHandler
+from opencode_go_proxy.meter import usage_events_path
+from opencode_go_proxy.secrets import clear_api_key_cache, resolve_api_key
+from opencode_go_proxy.usage_poller import clear_cache as clear_usage_poller_cache
+
+SCRATCH_PORT_PREFERRED = 8792
+PROXY_TIMEOUT_SEC = 2.0
+# Must exceed PROXY_TIMEOUT_SEC * 3 attempts plus backoff so the proxy always
+# times out client-side instead of receiving a late response.
+HANG_SLEEP_SEC = 20.0
+MOCK_SETTLE_SEC = 0.2  # let the proxy consume the committed chunk before the RST lands
+STREAM_CHUNK_COUNT = 40
+STREAM_CHUNK_DELAY_SEC = 0.05  # spread chunks so the test can cancel mid-stream
+MODEL = "deepseek-v4-flash"
+
+MODE_401 = "401"
+MODE_429 = "429"
+MODE_500 = "500"
+MODE_HANG = "hang"
+MODE_ABORT = "abort"
+MODE_EMPTY = "empty"
+MODE_STREAM = "stream"
+MODE_GARBAGE = "garbage"
+MODE_OK = "ok"
+
+RETRY_AFTER_VALUE = "2"
+
+
+def _sse_chunk(text: str) -> bytes:
+    chunk = {
+        "id": "chatcmpl-matrix",
+        "object": "chat.completion.chunk",
+        "model": MODEL,
+        "choices": [{"index": 0, "delta": {"content": text}}],
+    }
+    return b"data: " + json.dumps(chunk, separators=(",", ":")).encode("utf-8") + b"\n\n"
+
+
+def _failed_keychain_run(*args, **kwargs) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=args, returncode=1, stdout="")
+
+
+class RequestRecord:
+    """What the mock saw for one upstream request.
+
+    The authorization value is stored for in-memory comparison only and never
+    rendered into output or failure messages.
+    """
+
+    def __init__(self, path: str, headers: dict[str, str], raw_body: bytes) -> None:
+        self.path = path
+        # http.client title-cases header names on the wire; normalize for lookups.
+        self.headers = {name.lower(): value for name, value in headers.items()}
+        self.content_type = self.headers.get("content-type", "")
+        self.has_authorization = "authorization" in self.headers
+        authorization = self.headers.get("authorization", "")
+        self.authorization_is_bearer = authorization.startswith("Bearer ")
+        self.authorization_value = authorization
+        self.raw_body = raw_body
+
+
+class ScriptedUpstream:
+    """One scripted persona: records every request, then answers per `mode`."""
+
+    def __init__(self, mode: str) -> None:
+        self.mode = mode
+        self.requests: list[RequestRecord] = []
+        self.notes: list[str] = []
+
+    def record(self, path: str, headers: dict[str, str], raw_body: bytes) -> None:
+        self.requests.append(RequestRecord(path, headers, raw_body))
+
+    def note(self, message: str) -> None:
+        self.notes.append(message)
+
+    def reset_log(self) -> None:
+        self.requests.clear()
+        self.notes.clear()
+
+    @property
+    def count(self) -> int:
+        return len(self.requests)
+
+    def handle(self, handler: BaseHTTPRequestHandler) -> None:
+        handlers = {
+            MODE_401: self._respond_401,
+            MODE_429: self._respond_429,
+            MODE_500: self._respond_500,
+            MODE_HANG: self._respond_hang,
+            MODE_ABORT: self._respond_abort,
+            MODE_EMPTY: self._respond_empty,
+            MODE_STREAM: self._respond_stream,
+            MODE_GARBAGE: self._respond_garbage,
+            MODE_OK: self._respond_ok,
+        }
+        handlers[self.mode](handler)
+
+    def _send_json(
+        self,
+        handler: BaseHTTPRequestHandler,
+        status: int,
+        payload: dict,
+        extra_headers: dict[str, str] | None = None,
+    ) -> None:
+        raw = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        handler.send_response(status)
+        for name, value in (extra_headers or {}).items():
+            handler.send_header(name, value)
+        handler.send_header("content-type", "application/json")
+        handler.send_header("content-length", str(len(raw)))
+        handler.end_headers()
+        handler.wfile.write(raw)
+
+    def _send_sse_head(self, handler: BaseHTTPRequestHandler) -> None:
+        handler.send_response(200)
+        handler.send_header("content-type", "text/event-stream")
+        handler.end_headers()
+
+    def _respond_401(self, handler: BaseHTTPRequestHandler) -> None:
+        self._send_json(
+            handler,
+            401,
+            {"error": {"type": "authentication_error", "message": "upstream rejects the key"}},
+        )
+
+    def _respond_429(self, handler: BaseHTTPRequestHandler) -> None:
+        self._send_json(
+            handler,
+            429,
+            {"error": {"type": "rate_limit_error", "message": "slow down"}},
+            {"retry-after": RETRY_AFTER_VALUE},
+        )
+
+    def _respond_500(self, handler: BaseHTTPRequestHandler) -> None:
+        self._send_json(handler, 500, {"error": {"type": "server_error", "message": "boom"}})
+
+    def _respond_hang(self, handler: BaseHTTPRequestHandler) -> None:
+        time.sleep(HANG_SLEEP_SEC)
+        self.note("upstream woke from hang sleep after the proxy timed out")
+        self._send_json(
+            handler,
+            200,
+            {"id": "chatcmpl-late", "object": "chat.completion", "model": MODEL, "choices": []},
+        )
+
+    def _respond_abort(self, handler: BaseHTTPRequestHandler) -> None:
+        self._send_sse_head(handler)
+        handler.wfile.write(_sse_chunk("hel"))
+        handler.wfile.flush()
+        time.sleep(MOCK_SETTLE_SEC)
+        handler.connection.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, struct.pack("ii", 1, 0))
+        handler.connection.close()
+
+    def _respond_empty(self, handler: BaseHTTPRequestHandler) -> None:
+        self._send_sse_head(handler)
+        handler.wfile.write(b"data: [DONE]\n\n")
+        handler.wfile.flush()
+
+    def _respond_stream(self, handler: BaseHTTPRequestHandler) -> None:
+        self._send_sse_head(handler)
+        for index in range(STREAM_CHUNK_COUNT):
+            handler.wfile.write(_sse_chunk(f"chunk-{index}"))
+            handler.wfile.flush()
+            time.sleep(STREAM_CHUNK_DELAY_SEC)
+        handler.wfile.write(b"data: [DONE]\n\n")
+        handler.wfile.flush()
+
+    def _respond_garbage(self, handler: BaseHTTPRequestHandler) -> None:
+        self._send_sse_head(handler)
+        handler.wfile.write(b"\x00\xffthis is not SSE\r\nno data prefix here\r\n")
+        handler.wfile.flush()
+
+    def _respond_ok(self, handler: BaseHTTPRequestHandler) -> None:
+        self._send_json(
+            handler,
+            200,
+            {
+                "id": "chatcmpl-matrix",
+                "object": "chat.completion",
+                "model": MODEL,
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "ok"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            },
+        )
+
+
+class MockUpstreamHandler(BaseHTTPRequestHandler):
+    """HTTP surface for the scripted upstream; every request is recorded."""
+
+    protocol_version = "HTTP/1.0"
+    server_version = "MockUpstream/1.0"
+
+    def log_message(self, message_format: str, *args: object) -> None:
+        # The mock's access log is test noise; ScriptedUpstream holds the real log.
+        return
+
+    def do_POST(self) -> None:
+        length = int(self.headers.get("content-length") or "0")
+        raw_body = self.rfile.read(length) if length else b""
+        self.server.behavior.record(self.path, dict(self.headers), raw_body)
+        try:
+            self.server.behavior.handle(self)
+        except (BrokenPipeError, ConnectionResetError):
+            self.server.behavior.note("proxy abandoned the connection mid-response")
+
+
+class _MockServer(ThreadingHTTPServer):
+    daemon_threads = True
+    behavior: ScriptedUpstream
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.behavior = ScriptedUpstream(MODE_OK)
+
+
+class _ScratchProxyServer(ThreadingHTTPServer):
+    daemon_threads = True
+    config: ProxyConfig
+
+
+def _wait_for_listener(port: int, timeout_sec: float = 5.0) -> None:
+    deadline = time.monotonic() + timeout_sec
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.2):
+                return
+        except OSError:
+            time.sleep(0.01)
+    raise AssertionError(f"port {port} never accepted connections")
+
+
+def _pick_scratch_port() -> int:
+    """A free scratch port, preferring 8792 (never the live 8787).
+
+    Parallel verification agents share the 8791-8799 range, so a sibling may
+    hold the preferred port; fall back to any free scratch port, then to an
+    OS-assigned ephemeral port.
+    """
+    candidates = [SCRATCH_PORT_PREFERRED, *range(SCRATCH_PORT_PREFERRED + 1, SCRATCH_PORT_PREFERRED + 8)]
+    for port in candidates:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+            try:
+                probe.bind(("127.0.0.1", port))
+                return port
+            except OSError:
+                continue
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.bind(("127.0.0.1", 0))
+        return probe.getsockname()[1]
+
+
+@pytest.fixture
+def scratch_port() -> Generator[int, None, None]:
+    yield _pick_scratch_port()
+
+
+@pytest.fixture
+def mock_upstream() -> Generator[_MockServer, None, None]:
+    server = _MockServer(("127.0.0.1", 0), MockUpstreamHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    _wait_for_listener(server.server_address[1])
+    yield server
+    server.shutdown()
+    server.server_close()
+
+
+@pytest.fixture
+def proxy_env(mock_upstream: _MockServer) -> Generator[str, None, None]:
+    """Isolated env for the scratch proxy: no key env, loopback-only, fast retries."""
+    base_url = f"http://127.0.0.1:{mock_upstream.server_address[1]}"
+    with mock.patch.dict(
+        os.environ,
+        {
+            "OPENCODE_GO_API_KEY": "",
+            "OPENCODE_API_KEY": "",
+            "OPENCODE_GO_PROXY_RETRY_BASE_MS": "1",
+            "OPENCODE_GO_PROXY_MAX_RETRIES": "2",
+            "OPENCODE_GO_USAGE_URL": f"{base_url}/usage",
+            "HTTP_PROXY": "",
+            "HTTPS_PROXY": "",
+            "ALL_PROXY": "",
+            "http_proxy": "",
+            "https_proxy": "",
+            "all_proxy": "",
+            "SSL_CERT_FILE": "",
+            "SSL_CERT_DIR": "",
+            "NO_PROXY": "*",
+            "no_proxy": "*",
+        }
+    ):
+        clear_api_key_cache()
+        clear_usage_poller_cache()
+        yield base_url
+
+
+def _start_scratch_proxy(chat_base_url: str, port: int) -> _ScratchProxyServer:
+    server = _ScratchProxyServer(("127.0.0.1", port), ResponsesProxyHandler)
+    server.config = ProxyConfig(
+        bind="127.0.0.1",
+        port=port,
+        chat_base_url=chat_base_url,
+        api_key_env="OPENCODE_GO_API_KEY",
+        timeout_sec=PROXY_TIMEOUT_SEC,
+        max_body_bytes=20 * 1024 * 1024,
+    )
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    _wait_for_listener(port)
+    return server
+
+
+@pytest.fixture
+def proxy(proxy_env: str, scratch_port: int) -> Generator[_ScratchProxyServer, None, None]:
+    server = _start_scratch_proxy(proxy_env, scratch_port)
+    yield server
+    server.shutdown()
+    server.server_close()
+
+
+def responses_payload(*, stream: bool = False) -> dict:
+    return {"model": MODEL, "input": "Say something.", "stream": stream}
+
+
+def chat_payload() -> dict:
+    return {"model": MODEL, "messages": [{"role": "user", "content": "hi"}]}
+
+
+def http_request(
+    port: int,
+    method: str,
+    path: str,
+    *,
+    body: bytes | None = None,
+    headers: dict[str, str] | None = None,
+    timeout_sec: float = 15.0,
+) -> tuple[int, dict[str, str], bytes]:
+    """One round trip against the scratch proxy; the connection is always closed."""
+    conn = HTTPConnection("127.0.0.1", port, timeout=timeout_sec)
+    try:
+        conn.request(method, path, body, headers or {})
+        response = conn.getresponse()
+        raw = response.read()
+        status = response.status
+        response_headers = {name.lower(): value for name, value in response.getheaders()}
+        return status, response_headers, raw
+    finally:
+        conn.close()
+
+
+def post_json(port: int, path: str, payload: dict) -> tuple[int, dict[str, str], bytes]:
+    raw = json.dumps(payload).encode("utf-8")
+    return http_request(port, "POST", path, body=raw, headers={"content-type": "application/json"})
+
+
+def open_stream(
+    port: int, path: str, payload: dict, *, timeout_sec: float = 15.0
+) -> tuple[HTTPConnection, HTTPResponse]:
+    conn = HTTPConnection("127.0.0.1", port, timeout=timeout_sec)
+    conn.request("POST", path, json.dumps(payload).encode("utf-8"), {"content-type": "application/json"})
+    response = conn.getresponse()
+    return conn, response
+
+
+def read_until(response: HTTPResponse, marker: bytes, *, timeout_sec: float = 15.0) -> bytes:
+    """Read the SSE body until `marker` appears or the upstream closes the stream."""
+    accumulated = bytearray()
+    deadline = time.monotonic() + timeout_sec
+    while marker not in accumulated:
+        if time.monotonic() > deadline:
+            raise AssertionError(f"stream did not reach {marker!r} within {timeout_sec}s")
+        chunk = response.read1(8192)
+        if not chunk:
+            break
+        accumulated.extend(chunk)
+    return bytes(accumulated)
+
+
+def read_until_then_disconnect(
+    conn: HTTPConnection, response: HTTPResponse, marker: bytes, *, timeout_sec: float = 15.0
+) -> bytes:
+    """Read until `marker`, then close the connection as a client cancel would.
+
+    A graceful FIN is used, not an RST: on macOS a peer RST is only reported
+    through recv, while sends after a FIN-then-RST fail with EPIPE, which is
+    the write failure the proxy's disconnect detection watches for.
+    """
+    accumulated = read_until(response, marker, timeout_sec=timeout_sec)
+    conn.close()
+    return accumulated
+
+
+def meter_events() -> list[dict]:
+    try:
+        with open(usage_events_path(), encoding="utf-8") as handle:
+            return [json.loads(line) for line in handle if line.strip()]
+    except OSError:
+        return []
+
+
+def wait_for_event(predicate: Callable[[dict], bool], *, timeout_sec: float = 10.0) -> dict:
+    """Poll the meter file for an event matching `predicate` (async stream writes)."""
+    deadline = time.monotonic() + timeout_sec
+    while time.monotonic() < deadline:
+        for event in meter_events():
+            if predicate(event):
+                return event
+        time.sleep(0.05)
+    raise AssertionError(f"no meter event matched within {timeout_sec}s; saw {meter_events()}")
+
+
+class ExpectationCheck:
+    """Collect scenario contract checks so one run reports every mismatch."""
+
+    def __init__(self, scenario: str) -> None:
+        self.scenario = scenario
+        self.failures: list[str] = []
+
+    def check(self, label: str, condition: bool, actual: object) -> None:
+        if not condition:
+            self.failures.append(f"{label}: got {actual!r}")
+
+    def expect_equal(self, label: str, actual: object, expected: object) -> None:
+        if actual != expected:
+            self.failures.append(f"{label}: expected {expected!r}, got {actual!r}")
+
+    def finish(self) -> None:
+        if self.failures:
+            joined = "; ".join(self.failures)
+            raise AssertionError(f"{self.scenario}: {len(self.failures)} mismatch(es): {joined}")
+
+
+def test_scenario_01_upstream_401_relayed_verbatim(
+    proxy: _ScratchProxyServer, mock_upstream: _MockServer, scratch_port: int
+) -> None:
+    mock_upstream.behavior.mode = MODE_401
+    check = ExpectationCheck("scenario 01: 401 passthrough")
+    status, _headers, raw = post_json(scratch_port, "/chat/completions", chat_payload())
+    body = json.loads(raw)
+    check.expect_equal("client status", status, 401)
+    check.expect_equal("upstream error type relayed", body.get("error", {}).get("type"), "authentication_error")
+    check.expect_equal("upstream error message relayed", body.get("error", {}).get("message"), "upstream rejects the key")
+    check.expect_equal("upstream saw exactly one request", mock_upstream.behavior.count, 1)
+    first = mock_upstream.behavior.requests[0]
+    check.check(
+        "client auth forwarded as a bearer token",
+        first.has_authorization and first.authorization_is_bearer,
+        (first.has_authorization, first.authorization_is_bearer),
+    )
+    resolved_key = resolve_api_key(proxy.config, "matrix-check")
+    check.check(
+        "upstream received exactly the resolved key",
+        first.authorization_value == f"Bearer {resolved_key}",
+        first.authorization_value == f"Bearer {resolved_key}",
+    )
+    check.check("upstream got a JSON body", first.content_type.startswith("application/json"), first.content_type)
+    events = meter_events()
+    check.expect_equal("one meter row", len(events), 1)
+    check.expect_equal("meter status 401", events[-1].get("status"), 401)
+    check.check("no retries recorded for a permanent error", "retries" not in events[-1], events[-1])
+    check.finish()
+
+
+def test_scenario_02_429_retries_then_surfaces_retry_after(
+    proxy: _ScratchProxyServer, mock_upstream: _MockServer, scratch_port: int
+) -> None:
+    mock_upstream.behavior.mode = MODE_429
+    check = ExpectationCheck("scenario 02: 429 + retry-after")
+    status, headers, raw = post_json(scratch_port, "/v1/responses", responses_payload())
+    body = json.loads(raw)
+    message = body.get("error", {}).get("message", "")
+    check.expect_equal("client status", status, 429)
+    check.check("retry-after value surfaced in message", f"retry after {RETRY_AFTER_VALUE}s" in message, message)
+    check.check("retry-after header forwarded to client", "retry-after" in headers, headers.get("retry-after"))
+    check.expect_equal("upstream saw initial + 2 retries", mock_upstream.behavior.count, 3)
+    events = meter_events()
+    check.expect_equal("one meter row for the responses turn", len(events), 1)
+    check.expect_equal("meter status 429", events[-1].get("status"), 429)
+    check.expect_equal("meter counts the 2 retries", events[-1].get("retries"), 2)
+
+    mock_upstream.behavior.reset_log()
+    status, headers, raw = post_json(scratch_port, "/chat/completions", chat_payload())
+    check.expect_equal("verbatim relay keeps upstream status 429", status, 429)
+    check.expect_equal(
+        "verbatim relay keeps the upstream body",
+        json.loads(raw).get("error", {}).get("message"),
+        "slow down",
+    )
+    check.check("verbatim relay forwards retry-after header", "retry-after" in headers, headers.get("retry-after"))
+    check.expect_equal("verbatim relay also retried twice", mock_upstream.behavior.count, 3)
+    events = meter_events()
+    check.expect_equal("second meter row for the verbatim turn", len(events), 2)
+    check.expect_equal("verbatim meter status 429", events[-1].get("status"), 429)
+    check.expect_equal("verbatim meter counts the 2 retries", events[-1].get("retries"), 2)
+    check.finish()
+
+
+def test_scenario_03_500_retried_then_surfaces_502(
+    proxy: _ScratchProxyServer, mock_upstream: _MockServer, scratch_port: int
+) -> None:
+    mock_upstream.behavior.mode = MODE_500
+    check = ExpectationCheck("scenario 03: 500 retry")
+    status, _headers, raw = post_json(scratch_port, "/v1/responses", responses_payload())
+    body = json.loads(raw)
+    check.expect_equal("client status", status, 502)
+    check.check(
+        "proxy envelope names the upstream 500",
+        "upstream HTTP 500" in body.get("error", {}).get("message", ""),
+        body.get("error", {}).get("message", ""),
+    )
+    check.expect_equal("upstream saw initial + 2 retries", mock_upstream.behavior.count, 3)
+    event = meter_events()[-1]
+    check.expect_equal("meter status reflects the final 502", event.get("status"), 502)
+    check.expect_equal("meter counts the 2 retries", event.get("retries"), 2)
+    check.finish()
+
+
+def test_scenario_04_hang_times_out_504(
+    proxy: _ScratchProxyServer, mock_upstream: _MockServer, scratch_port: int
+) -> None:
+    mock_upstream.behavior.mode = MODE_HANG
+    check = ExpectationCheck("scenario 04: upstream hang")
+    started = time.monotonic()
+    status, _headers, raw = post_json(scratch_port, "/v1/responses", responses_payload())
+    elapsed = time.monotonic() - started
+    body = json.loads(raw)
+    check.expect_equal("client status", status, 504)
+    check.check(
+        "timeout message",
+        "timeout" in body.get("error", {}).get("message", ""),
+        body.get("error", {}).get("message", ""),
+    )
+    check.check("no hang: answered within 3 timeouts + slack", elapsed < 15.0, f"{elapsed:.1f}s")
+    check.expect_equal("upstream saw initial + 2 retries", mock_upstream.behavior.count, 3)
+    event = meter_events()[-1]
+    check.expect_equal("meter status 504", event.get("status"), 504)
+    check.expect_equal("meter counts the 2 retries", event.get("retries"), 2)
+    check.finish()
+
+
+def test_scenario_05_mid_stream_death_marks_aborted(
+    proxy: _ScratchProxyServer, mock_upstream: _MockServer, scratch_port: int
+) -> None:
+    mock_upstream.behavior.mode = MODE_ABORT
+    check = ExpectationCheck("scenario 05: mid-stream death after 200 head")
+    conn, response = open_stream(scratch_port, "/v1/responses", responses_payload(stream=True))
+    try:
+        check.expect_equal("200 head committed before upstream died", response.status, 200)
+        check.expect_equal("SSE content type", response.getheader("content-type", ""), "text/event-stream")
+        raw = read_until(response, b"[DONE]")
+    finally:
+        conn.close()
+    text = raw.decode("utf-8", errors="replace")
+    check.check("terminal error event sent", "response.error" in text, text[-300:])
+    check.check("abort message", "upstream stream aborted" in text, text[-300:])
+    check.check("no success claim", "response.completed" not in text, "response.completed present")
+    check.check("client saw the committed delta before the error", "output_text.delta" in text, text[:300])
+    check.expect_equal("upstream saw exactly one request", mock_upstream.behavior.count, 1)
+    event = wait_for_event(lambda candidate: candidate.get("status") == 502 and candidate.get("streamAborted") is True)
+    check.expect_equal("meter status 502", event.get("status"), 502)
+    check.expect_equal("meter marks stream aborted", event.get("streamAborted"), True)
+    check.expect_equal("one meter row", len(meter_events()), 1)
+    check.finish()
+
+
+def test_scenario_06_empty_completion_retried_once(
+    proxy: _ScratchProxyServer, mock_upstream: _MockServer, scratch_port: int
+) -> None:
+    mock_upstream.behavior.mode = MODE_EMPTY
+    check = ExpectationCheck("scenario 06: empty completion")
+    conn, response = open_stream(scratch_port, "/v1/responses", responses_payload(stream=True))
+    try:
+        raw = read_until(response, b"[DONE]")
+    finally:
+        conn.close()
+    text = raw.decode("utf-8", errors="replace")
+    check.check("empty-completion error surfaced", "response.error" in text and "empty_completion" in text, text[-300:])
+    check.check("no success claim", "response.completed" not in text, "response.completed present")
+    check.expect_equal("first empty attempt retried once", mock_upstream.behavior.count, 2)
+    event = wait_for_event(lambda candidate: candidate.get("emptyCompletion") is True)
+    check.expect_equal("meter marks empty completion", event.get("emptyCompletion"), True)
+    check.expect_equal("meter counts the empty retry", event.get("retries"), 1)
+    check.expect_equal("meter status is 502 (failed-turn contract)", event.get("status"), 502)
+    check.finish()
+
+
+def test_scenario_07_client_cancel_meters_zero(
+    proxy: _ScratchProxyServer, mock_upstream: _MockServer, scratch_port: int
+) -> None:
+    mock_upstream.behavior.mode = MODE_STREAM
+    check = ExpectationCheck("scenario 07: client cancel mid-stream")
+    conn, response = open_stream(scratch_port, "/v1/responses", responses_payload(stream=True))
+    try:
+        check.expect_equal("stream starts with a 200 head", response.status, 200)
+        raw = read_until_then_disconnect(conn, response, b"output_text.delta")
+        check.check(
+            "client saw streamed deltas before cancelling",
+            b"response.created" in raw and b"output_text.delta" in raw,
+            raw[:200],
+        )
+    finally:
+        conn.close()
+    event = wait_for_event(lambda candidate: candidate.get("status") == 0, timeout_sec=6.0)
+    check.expect_equal("meter status 0 for client cancel", event.get("status"), 0)
+    check.expect_equal("meter marks the stream aborted", event.get("streamAborted"), True)
+    check.expect_equal("exactly one meter row", len(meter_events()), 1)
+    check.finish()
+
+
+def test_scenario_08_garbage_sse_surfaces_error(
+    proxy: _ScratchProxyServer, mock_upstream: _MockServer, scratch_port: int
+) -> None:
+    mock_upstream.behavior.mode = MODE_GARBAGE
+    check = ExpectationCheck("scenario 08: garbage SSE")
+    started = time.monotonic()
+    conn, response = open_stream(scratch_port, "/v1/responses", responses_payload(stream=True))
+    try:
+        raw = read_until(response, b"[DONE]")
+    finally:
+        conn.close()
+    elapsed = time.monotonic() - started
+    text = raw.decode("utf-8", errors="replace")
+    check.check("error surfaced", "response.error" in text, text[-300:])
+    check.check("no hang", elapsed < 15.0, f"{elapsed:.1f}s")
+    check.expect_equal("upstream saw exactly one request", mock_upstream.behavior.count, 1)
+    event = wait_for_event(lambda candidate: candidate.get("status") == 502)
+    check.expect_equal("meter status 502 for unparseable stream", event.get("status"), 502)
+    check.check("no streamAborted claim (nothing was streamed)", event.get("streamAborted") is not True, event)
+    check.finish()
+
+
+def test_scenario_09_upstream_down_degrades_cleanly(
+    proxy: _ScratchProxyServer, mock_upstream: _MockServer, scratch_port: int
+) -> None:
+    mock_upstream.shutdown()
+    mock_upstream.server_close()
+    check = ExpectationCheck("scenario 09: upstream down")
+    status, _headers, _raw = http_request(scratch_port, "GET", "/health")
+    check.expect_equal("health 200 while upstream is down", status, 200)
+    status, _headers, raw = http_request(scratch_port, "GET", "/state")
+    check.expect_equal("state 200 while upstream is down", status, 200)
+    usage = json.loads(raw).get("usage", {})
+    check.check("usage degrades to zeros/null", usage.get("todayTurns") == 0 and usage.get("go") is None, usage)
+    status, _headers, raw = http_request(scratch_port, "GET", "/v1/models")
+    check.expect_equal("models 200 from the seed cache", status, 200)
+    ids = [entry.get("id") for entry in json.loads(raw).get("data", [])]
+    check.check("seed fallback non-empty", len(ids) > 0, ids)
+    status, _headers, raw = post_json(scratch_port, "/v1/responses", responses_payload())
+    body = json.loads(raw)
+    check.expect_equal("post surfaces 502 cleanly", status, 502)
+    check.check("proxy error envelope", "error" in body and bool(body["error"].get("message")), body)
+    event = meter_events()[-1]
+    check.expect_equal("meter status 502", event.get("status"), 502)
+    check.expect_equal("meter counts the 2 retries", event.get("retries"), 2)
+    status, _headers, _raw = http_request(scratch_port, "GET", "/health")
+    check.expect_equal("health still 200 after the failed post", status, 200)
+    check.finish()
+
+
+def test_scenario_10_keyless_returns_clean_error(
+    proxy: _ScratchProxyServer, mock_upstream: _MockServer, scratch_port: int
+) -> None:
+    check = ExpectationCheck("scenario 10: keyless")
+    with (
+        mock.patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "", "OPENCODE_API_KEY": ""}),
+        mock.patch("opencode_go_proxy.secrets.subprocess.run", side_effect=_failed_keychain_run),
+    ):
+        clear_api_key_cache()
+        status, _headers, raw = post_json(scratch_port, "/v1/responses", responses_payload())
+        body = json.loads(raw)
+        check.expect_equal("client status", status, 401)
+        check.check(
+            "clear missing-key message",
+            "OPENCODE_GO_API_KEY" in body.get("error", {}).get("message", ""),
+            body.get("error", {}).get("message", ""),
+        )
+        check.expect_equal("upstream never contacted", mock_upstream.behavior.count, 0)
+        events = meter_events()
+        check.expect_equal("one meter row", len(events), 1)
+        check.expect_equal("meter status 401", events[-1].get("status"), 401)
+        status, _headers, _raw = http_request(scratch_port, "GET", "/health")
+        check.expect_equal("health still 200", status, 200)
+    check.finish()
+
+
+def test_scenario_11_corrupt_catalog_recovers(proxy_env: str, scratch_port: int) -> None:
+    merged_path = catalog.merged_models_path()
+    with open(merged_path, "w", encoding="utf-8") as handle:
+        handle.write("this is not json {{{")
+    server = _start_scratch_proxy(proxy_env, scratch_port)
+    try:
+        check = ExpectationCheck("scenario 11: corrupt catalog")
+        status, _headers, _raw = http_request(scratch_port, "GET", "/health")
+        check.expect_equal("health 200 with corrupt catalog", status, 200)
+        status, _headers, raw = http_request(scratch_port, "GET", "/v1/models")
+        check.expect_equal("models endpoint 200", status, 200)
+        ids = [entry.get("id") for entry in json.loads(raw).get("data", [])]
+        check.check("models fall back to the seed set", len(ids) > 0, ids)
+        catalog.render_merged_catalog()
+        with open(merged_path, encoding="utf-8") as handle:
+            recovered = json.load(handle)
+        check.check(
+            "refresh rewrites valid JSON with a models list",
+            isinstance(recovered.get("models"), list),
+            type(recovered.get("models")).__name__,
+        )
+        status, _headers, raw = http_request(scratch_port, "GET", "/v1/models")
+        check.expect_equal("models endpoint 200 after refresh", status, 200)
+        ids = [entry.get("id") for entry in json.loads(raw).get("data", [])]
+        check.check("models still served after refresh", len(ids) > 0, ids)
+        check.finish()
+    finally:
+        server.shutdown()
+        server.server_close()

--- a/tests/test_failure_matrix.py
+++ b/tests/test_failure_matrix.py
@@ -4,9 +4,10 @@ Every scenario drives the real proxy HTTP surface (in-process server on the
 scratch port 8792) against an http.server mock upstream scripted per scenario,
 then verifies the client-visible response, the usage-meter row, and the mock's
 request log. Offline and deterministic: all traffic is loopback, the state dir
-is a per-test tmp dir, and the key env is cleared so key resolution walks to
-the macOS keychain (the resolved value never appears in test output) or fails
-for the keyless scenario.
+is a per-test tmp dir, and the proxy env carries an explicit fake key
+("test-key") so key resolution never touches the environment or the macOS
+keychain. The keyless scenario clears the key itself and forces keychain
+failure to prove the 401 contract.
 
 Contract expectations come from the reliability spec; where the current code
 behaves differently the scenario FAILS and reports the mismatch with evidence
@@ -303,12 +304,18 @@ def mock_upstream() -> Generator[_MockServer, None, None]:
 
 @pytest.fixture
 def proxy_env(mock_upstream: _MockServer) -> Generator[str, None, None]:
-    """Isolated env for the scratch proxy: no key env, loopback-only, fast retries."""
+    """Scratch-proxy env: explicit fake key, loopback-only, fast retries.
+
+    OPENCODE_GO_API_KEY is set to a literal fake key so key resolution is
+    deterministic and never consults the ambient env or the macOS keychain
+    (CI has neither). OPENCODE_API_KEY is pinned empty so an inherited
+    standard key cannot leak in either.
+    """
     base_url = f"http://127.0.0.1:{mock_upstream.server_address[1]}"
     with mock.patch.dict(
         os.environ,
         {
-            "OPENCODE_GO_API_KEY": "",
+            "OPENCODE_GO_API_KEY": "test-key",
             "OPENCODE_API_KEY": "",
             "OPENCODE_GO_PROXY_RETRY_BASE_MS": "1",
             "OPENCODE_GO_PROXY_MAX_RETRIES": "2",
@@ -701,6 +708,9 @@ def test_scenario_10_keyless_returns_clean_error(
     proxy: _ScratchProxyServer, mock_upstream: _MockServer, scratch_port: int
 ) -> None:
     check = ExpectationCheck("scenario 10: keyless")
+    # Keyless by design: override the fixture's fake key with empty values and
+    # force keychain lookup to fail, proving the proxy rejects with 401 before
+    # any upstream contact.
     with (
         mock.patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "", "OPENCODE_API_KEY": ""}),
         mock.patch("opencode_go_proxy.secrets.subprocess.run", side_effect=_failed_keychain_run),

--- a/tests/test_meter.py
+++ b/tests/test_meter.py
@@ -13,6 +13,7 @@ from opencode_go_proxy.meter import (
     record_usage_event,
     state_dir,
     usage_events_path,
+    usage_summary,
 )
 
 
@@ -120,6 +121,165 @@ class MeterRecordTests(unittest.TestCase):
         # True default (env cleared, not the autouse tmp override).
         with mock.patch.dict(os.environ, {}, clear=True):
             self.assertIn(".codex", state_dir())
+
+
+class MeterSummaryFoldTests(unittest.TestCase):
+    """O(1) fold: aggregate equals a full scan across growth, shrink, rollover."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.mkdtemp(prefix="ogg-meter-fold-")
+        self.addCleanup(lambda: shutil.rmtree(self.tmp, ignore_errors=True))
+        self._env = mock.patch.dict(os.environ, {STATE_DIR_ENV: self.tmp})
+        self._env.start()
+        self.addCleanup(self._env.stop)
+
+    def _now(self) -> datetime.datetime:
+        """A machine-local now: the fold buckets days in the local tz."""
+        return datetime.datetime.now().astimezone()
+
+    def _record(self, **kwargs) -> None:
+        record_usage_event(**kwargs)
+
+    def _force_rescan(self) -> None:
+        """Touch the meter file so the fingerprint no longer matches the fold."""
+        os.utime(usage_events_path())
+
+    def _append_line(self, text: str) -> None:
+        with open(usage_events_path(), "a", encoding="utf-8") as handle:
+            handle.write(text + "\n")
+
+    def _iso_now(self) -> str:
+        instant = datetime.datetime.now(datetime.UTC)
+        return instant.isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+    def test_second_call_serves_aggregate_without_rereading(self) -> None:
+        self._record(model="m", status=200, duration_ms=1, total_tokens=10)
+        self._record(model="m", status=200, duration_ms=1, total_tokens=20)
+        now = self._now()
+        first = usage_summary(now)
+        # The fold is warm: a second summary must not open the file at all.
+        with mock.patch("opencode_go_proxy.meter.open", side_effect=AssertionError("file re-read")):
+            second = usage_summary(now)
+        self.assertEqual(first, second)
+        self.assertEqual(first["todayTurns"], 2)
+        self.assertEqual(first["todayTokens"], 30)
+
+    def test_appended_events_fold_from_tail(self) -> None:
+        now = self._now()
+        self._record(model="m1", status=200, duration_ms=1, total_tokens=10)
+        usage_summary(now)  # establish the fold
+        # A write that bypasses record_usage_event grows the file externally.
+        self._append_line(
+            f'{{"at": "{self._iso_now()}", "model": "m2", "status": 200, '
+            f'"provider": "zen", "totalTokens": 42}}'
+        )
+        agg = usage_summary(now)
+        self.assertEqual(agg["todayTurns"], 2)
+        self.assertEqual(agg["todayTokens"], 52)
+        self._force_rescan()
+        self.assertEqual(agg, usage_summary(now))
+
+    def test_truncated_file_forces_full_rescan(self) -> None:
+        now = self._now()
+        self._record(model="m1", status=200, duration_ms=1, total_tokens=10)
+        self._record(model="m2", status=200, duration_ms=1, total_tokens=20)
+        usage_summary(now)  # establish the fold covering both events
+        path = usage_events_path()
+        with open(path, "rb") as handle:
+            first_line = handle.readline()
+        with open(path, "wb") as handle:
+            handle.write(first_line)
+        summary = usage_summary(now)
+        self.assertEqual(summary["todayTurns"], 1)
+        self.assertEqual(summary["todayTokens"], 10)
+        self.assertEqual(summary["model"], "m1")
+
+    def test_replaced_file_forces_full_rescan(self) -> None:
+        now = self._now()
+        self._record(model="m1", status=200, duration_ms=1, total_tokens=10)
+        usage_summary(now)  # establish the fold
+        replacement = usage_events_path() + ".replacement"
+        with open(replacement, "w", encoding="utf-8") as handle:
+            handle.write(
+                f'{{"at": "{self._iso_now()}", "model": "replacement", '
+                f'"status": 200, "totalTokens": 99}}'
+            )
+        os.replace(replacement, usage_events_path())  # new inode
+        summary = usage_summary(now)
+        self.assertEqual(summary["todayTurns"], 1)
+        self.assertEqual(summary["todayTokens"], 99)
+        self.assertEqual(summary["model"], "replacement")
+
+    def test_provider_filtered_rollups_match_full_scan(self) -> None:
+        now = self._now()
+        self._record(model="zen-m", status=200, duration_ms=1, total_tokens=30, provider="zen")
+        self._record(model="go-m", status=200, duration_ms=1, total_tokens=50)
+        self._record(model="native-m", status=200, duration_ms=1, total_tokens=70, provider="native")
+        usage_summary(now)  # establish the fold
+        for provider in (None, "zen", "opencode-go", "native"):
+            rolled = usage_summary(now, provider=provider)
+            self._force_rescan()
+            self.assertEqual(rolled, usage_summary(now, provider=provider))
+        self.assertEqual(usage_summary(now, provider="zen")["todayTokens"], 30)
+        self.assertEqual(usage_summary(now, provider="opencode-go")["todayTokens"], 50)
+        self.assertEqual(usage_summary(now)["todayTokens"], 150)
+
+    def test_midnight_rollover_moves_today(self) -> None:
+        now = self._now()
+        self._record(model="m", status=200, duration_ms=1, total_tokens=40)
+        today = usage_summary(now)
+        self.assertEqual(today["todayTurns"], 1)
+        self.assertEqual(today["todayTokens"], 40)
+        tomorrow = now + datetime.timedelta(days=1)
+        rolled = usage_summary(tomorrow)
+        self.assertEqual(rolled["todayTurns"], 0)
+        self.assertEqual(rolled["todayTokens"], 0)
+        by_day = {day["date"]: day["tokens"] for day in rolled["last7d"]}
+        self.assertEqual(by_day[now.date().isoformat()], 40)
+        self._force_rescan()
+        self.assertEqual(rolled, usage_summary(tomorrow))
+
+    def test_concurrent_records_are_safe(self) -> None:
+        import threading
+
+        now = self._now()
+        self._record(model="m0", status=200, duration_ms=1, total_tokens=1)
+        usage_summary(now)  # establish the fold
+        recorded_counts: list[int] = []
+
+        def worker() -> None:
+            recorded = 0
+            for index in range(25):
+                record_usage_event(
+                    model=f"m{index}", status=200, duration_ms=1, total_tokens=index + 1
+                )
+                recorded += 1
+            recorded_counts.append(recorded)
+
+        threads = [threading.Thread(target=worker) for _ in range(4)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+        # A worker that raised would never append, so the count check below
+        # would fail on its missing entry.
+        self.assertEqual(recorded_counts, [25, 25, 25, 25])
+        agg = usage_summary(now)
+        self.assertEqual(agg["todayTurns"], 1 + 4 * 25)
+        self.assertEqual(agg["todayTokens"], 1 + 4 * sum(range(1, 26)))
+        self._force_rescan()
+        self.assertEqual(agg, usage_summary(now))
+
+    def test_unreadable_file_degrades_to_zeros(self) -> None:
+        now = self._now()
+        self._record(model="m", status=200, duration_ms=1, total_tokens=10)
+        usage_summary(now)  # establish the fold
+        with mock.patch("opencode_go_proxy.meter.os.stat", side_effect=OSError("boom")):
+            summary = usage_summary(now)
+        self.assertEqual(summary["todayTurns"], 0)
+        self.assertEqual(summary["todayTokens"], 0)
+        self.assertIsNone(summary["model"])
+        self.assertEqual(len(summary["last7d"]), 7)
 
 
 if __name__ == "__main__":

--- a/tests/test_native_coexist.py
+++ b/tests/test_native_coexist.py
@@ -1,0 +1,486 @@
+"""Native + Go + Zen coexistence: routing isolation, auth isolation, concurrency.
+
+The offline block runs the real proxy in-process against a single local
+recording backend that stands in for every upstream (native Responses API,
+opencode-go chat completions, zen chat completions). Every leg is
+deterministic and network-free, so the whole matrix runs in CI.
+
+The live block (skipped unless NATIVE_COEXIST_LIVE=1) repeats the go/zen legs
+against the real opencode.ai upstreams with the keychain key, so the
+"real upstream response, not the mock" claim is verified against production.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import threading
+from contextlib import contextmanager
+from http.client import HTTPConnection
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from types import SimpleNamespace
+from typing import ClassVar
+from unittest import mock
+
+import pytest
+
+from opencode_go_proxy import passthrough
+from opencode_go_proxy.app import ProxyConfig, ResponsesProxyHandler
+from opencode_go_proxy.meter import state_dir
+from opencode_go_proxy.secrets import clear_api_key_cache
+
+CLIENT_AUTH = "Bearer CLIENT_FAKE_TOKEN"
+GO_FAKE_KEY = "sk-test-go-key-not-secret"
+NATIVE_TEXT = "MOCK_NATIVE"
+GO_TEXT = "MOCK_GO"
+ZEN_TEXT = "MOCK_ZEN"
+
+NATIVE_BASE_PATH = "/codex"
+GO_BASE_PATH = "/go"
+ZEN_BASE_PATH = "/zen"
+
+NATIVE_RESPONSE: dict = {
+    "id": "mock-1",
+    "object": "response",
+    "status": "completed",
+    "output": [{"type": "message", "content": [{"type": "output_text", "text": NATIVE_TEXT}]}],
+}
+
+ZEN_ERROR_BODY: dict = {
+    "type": "error",
+    "error": {"type": "RateLimitError", "message": "free tier limit exceeded"},
+    "metadata": {},
+}
+
+
+def _chat_completion(text: str) -> dict:
+    return {
+        "id": "cmpl-mock",
+        "object": "chat.completion",
+        "model": "mock",
+        "choices": [
+            {"index": 0, "finish_reason": "stop", "message": {"role": "assistant", "content": text}}
+        ],
+        "usage": {"prompt_tokens": 4, "completion_tokens": 2, "total_tokens": 6},
+    }
+
+
+class _RecordingBackend(BaseHTTPRequestHandler):
+    """One local backend for every upstream role, chosen by URL prefix.
+
+    /codex/* -> native Responses API (returns NATIVE_RESPONSE)
+    /go/*    -> opencode-go chat completions (returns _chat_completion(GO_TEXT))
+    /zen/*   -> zen chat completions (429 zen envelope for the free model,
+                otherwise _chat_completion(ZEN_TEXT))
+    """
+
+    captured: ClassVar[list[dict]] = []
+
+    def _record_request(self) -> dict:
+        length = int(self.headers.get("content-length", "0"))
+        body = self.rfile.read(length)
+        record = {
+            "path": self.path,
+            "headers": {name.lower(): value for name, value in self.headers.items()},
+            "body": body,
+        }
+        type(self).captured.append(record)
+        return record
+
+    def _emit(self, status: int, content_type: str, payload: bytes) -> None:
+        self.send_response(status)
+        self.send_header("content-type", content_type)
+        self.send_header("content-length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def do_POST(self) -> None:
+        record = self._record_request()
+        if self.path.startswith(NATIVE_BASE_PATH):
+            self._emit(200, "application/json", json.dumps(NATIVE_RESPONSE).encode())
+            return
+        if self.path.startswith(GO_BASE_PATH):
+            self._emit(200, "application/json", json.dumps(_chat_completion(GO_TEXT)).encode())
+            return
+        if self.path.startswith(ZEN_BASE_PATH):
+            try:
+                model = json.loads(record["body"]).get("model", "")
+            except (ValueError, TypeError):
+                model = ""
+            if model == "deepseek-v4-flash-free":
+                self._emit(429, "application/json", json.dumps(ZEN_ERROR_BODY).encode())
+                return
+            self._emit(200, "application/json", json.dumps(_chat_completion(ZEN_TEXT)).encode())
+            return
+        self._emit(404, "application/json", b'{"error":"unmapped path"}')
+
+    def log_message(self, format: str, *args: object) -> None:
+        pass
+
+
+def _start_server(handler: type[BaseHTTPRequestHandler]) -> tuple[int, ThreadingHTTPServer]:
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    httpd = ThreadingHTTPServer(("127.0.0.1", port), handler)
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    return port, httpd
+
+
+@pytest.fixture()
+def backend() -> str:
+    _RecordingBackend.captured = []
+    port, httpd = _start_server(_RecordingBackend)
+    yield f"http://127.0.0.1:{port}"
+    httpd.shutdown()
+    httpd.server_close()
+
+
+def _make_config(chat_base_url: str) -> ProxyConfig:
+    return ProxyConfig(
+        bind="127.0.0.1",
+        port=8791,
+        chat_base_url=chat_base_url,
+        api_key_env="OPENCODE_GO_API_KEY",
+        timeout_sec=15,
+        max_body_bytes=20 * 1024 * 1024,
+    )
+
+
+@pytest.fixture()
+def proxy_server(backend: str) -> int:
+    port, httpd = _start_server(ResponsesProxyHandler)
+    httpd.config = _make_config(chat_base_url=f"{backend}{GO_BASE_PATH}")  # type: ignore[attr-defined]
+    yield port
+    httpd.shutdown()
+    httpd.server_close()
+
+
+@pytest.fixture()
+def offline_env(backend: str):
+    """Point every upstream leg at the local recording backend, offline."""
+    env = {
+        passthrough.NATIVE_BASE_URL_ENV: f"{backend}{NATIVE_BASE_PATH}",
+        passthrough.NATIVE_INSECURE_ENV: "1",
+        "OPENCODE_ZEN_BASE_URL": f"{backend}{ZEN_BASE_PATH}",
+        "OPENCODE_GO_API_KEY": GO_FAKE_KEY,
+        "OPENCODE_GO_PROXY_MAX_RETRIES": "0",
+    }
+    with mock.patch.dict(os.environ, env):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _fresh_api_key_cache():
+    """Each test resolves its own key: offline tests must never reuse a
+    keychain credential another module (or a live test) cached."""
+    clear_api_key_cache()
+    yield
+    clear_api_key_cache()
+
+
+def _seed_native_capture(*slugs: str) -> None:
+    state = state_dir()
+    os.makedirs(state, exist_ok=True)
+    with open(os.path.join(state, "native-models.json"), "w") as handle:
+        json.dump(
+            {
+                "captured_at": "2026-08-14T00:00:00Z",
+                "models": [{"slug": slug} for slug in slugs],
+            },
+            handle,
+        )
+
+
+def _seed_zen_capture(*model_ids: str) -> None:
+    state = state_dir()
+    os.makedirs(state, exist_ok=True)
+    with open(os.path.join(state, "zen-models.json"), "w") as handle:
+        json.dump(
+            {"fetched_at": "2026-08-14T00:00:00Z", "models": [{"id": model_id} for model_id in model_ids]},
+            handle,
+        )
+    with open(os.path.join(state, "zen-catalog.json"), "w") as handle:
+        json.dump(
+            {
+                "version": 1,
+                "fetched_at": "2026-08-14T00:00:00Z",
+                "models": {model_id: {"family": "openai_chat"} for model_id in model_ids},
+            },
+            handle,
+        )
+
+
+def _partition_captured() -> tuple[list[dict], list[dict], list[dict]]:
+    native = [r for r in _RecordingBackend.captured if r["path"].startswith(NATIVE_BASE_PATH)]
+    go = [r for r in _RecordingBackend.captured if r["path"].startswith(GO_BASE_PATH)]
+    zen = [r for r in _RecordingBackend.captured if r["path"].startswith(ZEN_BASE_PATH)]
+    return native, go, zen
+
+
+def _auth_values(record: dict) -> list[str]:
+    return [value for name, value in record["headers"].items() if name == "authorization"]
+
+
+def _post(port: int, payload: dict, auth: str | None = None) -> SimpleNamespace:
+    headers = {"content-type": "application/json"}
+    if auth is not None:
+        headers["authorization"] = auth
+    conn = HTTPConnection("127.0.0.1", port, timeout=15)
+    conn.request("POST", "/v1/responses", json.dumps(payload).encode(), headers)
+    resp = conn.getresponse()
+    raw = resp.read()
+    conn.close()
+    return SimpleNamespace(status=resp.status, raw=raw)
+
+
+def _get(port: int, path: str) -> SimpleNamespace:
+    conn = HTTPConnection("127.0.0.1", port, timeout=15)
+    conn.request("GET", path)
+    resp = conn.getresponse()
+    raw = resp.read()
+    conn.close()
+    return SimpleNamespace(status=resp.status, raw=raw)
+
+
+def test_native_relays_verbatim_with_client_auth_only(backend: str, proxy_server: int, offline_env) -> None:
+    """(a) A bare native model relays to the native backend with the client's
+    own Authorization header and nothing else — the go key never appears."""
+    _seed_native_capture("gpt-5.6-terra")
+    payload = {"model": "gpt-5.6-terra", "input": "hi", "stream": False}
+    resp = _post(proxy_server, payload, auth=CLIENT_AUTH)
+
+    assert resp.status == 200
+    assert json.loads(resp.raw)["output"][0]["content"][0]["text"] == NATIVE_TEXT
+
+    native, go, zen = _partition_captured()
+    assert go == [] and zen == []
+    assert len(native) == 1
+    recorded = native[0]
+    assert recorded["path"] == f"{NATIVE_BASE_PATH}/v1/responses"
+    assert json.loads(recorded["body"]) == payload
+    # Exactly one Authorization header, the client's; no second auth header
+    # (the go key would arrive as "authorization" if the relay attached it).
+    assert _auth_values(recorded) == [CLIENT_AUTH]
+    assert GO_FAKE_KEY not in json.dumps(recorded["headers"])
+
+
+def test_go_route_never_touches_native_backend(backend: str, proxy_server: int, offline_env) -> None:
+    """(b) opencode-go/ always translates through the go upstream; the native
+    backend must not see the request, and the client auth must not leak
+    upstream (the proxy substitutes its own key)."""
+    resp = _post(proxy_server, {"model": "opencode-go/deepseek-v4-flash", "input": "hi"}, auth=CLIENT_AUTH)
+
+    assert resp.status == 200
+    body = json.loads(resp.raw)
+    assert body["object"] == "response"
+    assert body["output"][0]["content"][0]["text"] == GO_TEXT
+
+    native, go, zen = _partition_captured()
+    assert native == [] and zen == []
+    assert len(go) == 1
+    assert go[0]["path"] == f"{GO_BASE_PATH}/chat/completions"
+    assert _auth_values(go[0]) == [f"Bearer {GO_FAKE_KEY}"]
+    assert CLIENT_AUTH not in json.dumps(go[0]["headers"])
+
+
+def test_zen_free_model_relays_upstream_error_envelope(backend: str, proxy_server: int, offline_env) -> None:
+    """(c) zen/ always goes to the zen upstream; an upstream error is relayed
+    with the zen error type, never replaced by the native backend's body."""
+    resp = _post(
+        proxy_server, {"model": "zen/deepseek-v4-flash-free", "input": "hi"}, auth=CLIENT_AUTH
+    )
+
+    assert resp.status == 429
+    assert NATIVE_TEXT not in resp.raw.decode("utf-8", "replace")
+    body = json.loads(resp.raw)
+    assert body["error"]["type"] == "RateLimitError"
+
+    native, go, zen = _partition_captured()
+    assert native == [] and go == []
+    assert len(zen) == 1
+    assert zen[0]["path"] == f"{ZEN_BASE_PATH}/chat/completions"
+    assert json.loads(zen[0]["body"])["model"] == "deepseek-v4-flash-free"
+    assert _auth_values(zen[0]) == [f"Bearer {GO_FAKE_KEY}"]
+
+
+def test_zen_route_translates_success(backend: str, proxy_server: int, offline_env) -> None:
+    """A zen model on a working upstream round-trips to a Responses object
+    without ever touching the native backend."""
+    _seed_zen_capture("deepseek-v4-flash")
+    resp = _post(proxy_server, {"model": "zen/deepseek-v4-flash", "input": "hi"})
+
+    assert resp.status == 200
+    body = json.loads(resp.raw)
+    assert body["object"] == "response"
+    assert body["output"][0]["content"][0]["text"] == ZEN_TEXT
+
+    native, go, zen = _partition_captured()
+    assert native == [] and go == []
+    assert len(zen) == 1
+    assert json.loads(zen[0]["body"])["model"] == "deepseek-v4-flash"
+
+
+def test_concurrent_requests_do_not_cross_contaminate(backend: str, proxy_server: int, offline_env) -> None:
+    """(d) native + go + zen fired at the same time each get their own result
+    and the native backend log shows exactly the native request."""
+    _seed_native_capture("gpt-5.6-terra")
+    payloads = [
+        {"model": "gpt-5.6-terra", "input": "hi", "stream": False},
+        {"model": "opencode-go/deepseek-v4-flash", "input": "hi"},
+        {"model": "zen/deepseek-v4-flash-free", "input": "hi"},
+    ]
+    results: list[SimpleNamespace | None] = [None] * len(payloads)
+    failures: list[Exception] = []
+    barrier = threading.Barrier(len(payloads))
+
+    def fire(index: int, payload: dict) -> None:
+        barrier.wait()
+        try:
+            results[index] = _post(proxy_server, payload, auth=CLIENT_AUTH)
+        except Exception as exc:  # noqa: BLE001 - surface any transport failure
+            failures.append(exc)
+
+    threads = [threading.Thread(target=fire, args=(index, payload)) for index, payload in enumerate(payloads)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=30)
+
+    assert failures == []
+    native_result = json.loads(results[0].raw)
+    assert results[0].status == 200 and native_result["id"] == "mock-1"
+    go_result = json.loads(results[1].raw)
+    assert results[1].status == 200 and go_result["output"][0]["content"][0]["text"] == GO_TEXT
+    zen_result = json.loads(results[2].raw)
+    assert results[2].status == 429 and zen_result["error"]["type"] == "RateLimitError"
+
+    native, go, zen = _partition_captured()
+    assert len(native) == 1 and len(go) == 1 and len(zen) == 1
+    assert json.loads(native[0]["body"])["model"] == "gpt-5.6-terra"
+    assert json.loads(go[0]["body"])["model"] == "deepseek-v4-flash"
+    assert json.loads(zen[0]["body"])["model"] == "deepseek-v4-flash-free"
+
+
+def test_models_list_serves_each_provider_without_collision(backend: str, proxy_server: int, offline_env) -> None:
+    """(e) /v1/models serves native bare, opencode-go bare, and zen prefixed;
+    the same upstream id from go and zen stays two distinct ids."""
+    from opencode_go_proxy import catalog as proxy_catalog
+
+    _seed_native_capture("gpt-5.6-terra")
+    _seed_zen_capture("deepseek-v4-flash")
+    proxy_catalog.render_merged_catalog()
+
+    resp = _get(proxy_server, "/v1/models")
+    assert resp.status == 200
+    ids = [entry["id"] for entry in json.loads(resp.raw)["data"]]
+
+    assert "gpt-5.6-terra" in ids          # native, bare
+    assert "deepseek-v4-flash" in ids      # opencode-go, bare
+    assert "zen/deepseek-v4-flash" in ids  # zen, prefixed
+    # The go bare slug and the zen-prefixed slug are distinct ids: the zen
+    # model never shadows (or duplicates) the go model under the bare slug.
+    assert ids.count("deepseek-v4-flash") == 1
+    assert ids.count("zen/deepseek-v4-flash") == 1
+    assert len(ids) == len(set(ids))
+
+
+LIVE = os.environ.get("NATIVE_COEXIST_LIVE") == "1"
+live_only = pytest.mark.skipif(not LIVE, reason="live upstream test; set NATIVE_COEXIST_LIVE=1")
+
+
+@contextmanager
+def _cleared_key_env():
+    """Temporarily drop every key env var so resolution falls to the keychain."""
+    key_envs = ("OPENCODE_GO_API_KEY", "OPENCODE_API_KEY")
+    saved = {name: os.environ.get(name) for name in key_envs}
+    for name in key_envs:
+        os.environ.pop(name, None)
+    try:
+        yield
+    finally:
+        for name, value in saved.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+
+
+def _live_proxy(backend: str) -> tuple[int, ThreadingHTTPServer]:
+    """Real-upstream proxy: default go base (opencode.ai) in the config, only
+    the native leg pointed at the recording backend."""
+    port, httpd = _start_server(ResponsesProxyHandler)
+    httpd.config = _make_config(chat_base_url="https://opencode.ai/zen/go/v1")  # type: ignore[attr-defined]
+    return port, httpd
+
+
+@live_only
+def test_live_go_route_hits_real_upstream_not_mock(backend: str) -> None:
+    """(b live) opencode-go/deepseek-v4-flash goes to the real opencode.ai go
+    upstream with the keychain key; the native mock sees nothing and the
+    response is a real upstream verdict (200 or an upstream 4xx), never
+    MOCK_NATIVE."""
+    port, httpd = _live_proxy(backend)
+    try:
+        with _cleared_key_env(), mock.patch.dict(
+            os.environ,
+            {
+                passthrough.NATIVE_BASE_URL_ENV: f"{backend}{NATIVE_BASE_PATH}",
+                passthrough.NATIVE_INSECURE_ENV: "1",
+                "OPENCODE_GO_PROXY_MAX_RETRIES": "0",
+            },
+        ):
+            resp = _post(
+                port,
+                {"model": "opencode-go/deepseek-v4-flash", "input": "hi"},
+                auth=CLIENT_AUTH,
+            )
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+
+    assert NATIVE_TEXT not in resp.raw.decode("utf-8", "replace")
+    native, _go, zen = _partition_captured()
+    assert native == [] and zen == []
+    assert resp.status in (200, 401, 403, 429)
+    if resp.status == 200:
+        body = json.loads(resp.raw)
+        assert body["object"] == "response"
+        message_item = next(item for item in body["output"] if item.get("type") == "message")
+        assert message_item["content"][0]["text"] not in ("", NATIVE_TEXT)
+
+
+@live_only
+def test_live_zen_route_hits_real_upstream_not_mock(backend: str) -> None:
+    """(c live) zen/deepseek-v4-flash-free goes to the real zen upstream; a
+    free-tier 429 with the zen error envelope is a valid zen response, and the
+    native mock sees nothing."""
+    port, httpd = _live_proxy(backend)
+    try:
+        with _cleared_key_env(), mock.patch.dict(
+            os.environ,
+            {
+                passthrough.NATIVE_BASE_URL_ENV: f"{backend}{NATIVE_BASE_PATH}",
+                passthrough.NATIVE_INSECURE_ENV: "1",
+                "OPENCODE_GO_PROXY_MAX_RETRIES": "1",
+            },
+        ):
+            resp = _post(
+                port,
+                {"model": "zen/deepseek-v4-flash-free", "input": "hi"},
+                auth=CLIENT_AUTH,
+            )
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+
+    assert NATIVE_TEXT not in resp.raw.decode("utf-8", "replace")
+    native, go, _zen = _partition_captured()
+    assert native == [] and go == []
+    assert resp.status in (200, 401, 403, 429)
+    if resp.status == 429:
+        body = json.loads(resp.raw)
+        assert "error" in body and "type" in body["error"]
+

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -4,6 +4,7 @@ import tempfile
 import unittest
 from unittest import mock
 
+from opencode_go_proxy import protocol
 from opencode_go_proxy.codex_tools import load_snapshot_tools
 from opencode_go_proxy.protocol import (
     IMAGE_MODEL_DEFAULT,
@@ -419,6 +420,106 @@ class CacheAccountingTests(unittest.TestCase):
             }
         )
         self.assertEqual(response["usage"]["input_tokens_details"], {"cached_tokens": 99})
+
+
+class CatalogCacheCoalescingTests(unittest.TestCase):
+    """The three catalog views share one parse, invalidated by file mtime."""
+
+    @staticmethod
+    def _write_catalog(models: list[dict]) -> str:
+        path = os.path.join(tempfile.mkdtemp(), "catalog.json")
+        with open(path, "w") as handle:
+            json.dump({"models": models}, handle)
+        return path
+
+    @staticmethod
+    def _bump_mtime(path: str) -> None:
+        stamp = os.stat(path).st_mtime_ns + 1_000_000_000
+        os.utime(path, ns=(stamp, stamp))
+
+    @staticmethod
+    def _parse_counter(catalog_path: str):
+        """Count catalog file reads; other file traffic passes through uncounted."""
+        calls = {"count": 0}
+        real_open = open
+
+        class _CountingHandle:
+            def __init__(self, wrapped):
+                self._wrapped = wrapped
+
+            def __enter__(self):
+                return self._wrapped.__enter__()
+
+            def __exit__(self, *exc):
+                return self._wrapped.__exit__(*exc)
+
+            def __iter__(self):
+                return iter(self._wrapped)
+
+            def __getattr__(self, name):
+                return getattr(self._wrapped, name)
+
+        def counting_open(path, *args, **kwargs):
+            mode = args[0] if args else kwargs.get("mode", "r")
+            if path == catalog_path and "w" not in mode and "a" not in mode and "+" not in mode:
+                calls["count"] += 1
+            return _CountingHandle(real_open(path, *args, **kwargs))
+
+        return mock.patch("builtins.open", side_effect=counting_open), calls
+
+    def test_stable_file_parsed_once_for_all_three_views(self) -> None:
+        catalog = self._write_catalog(
+            [
+                {"slug": "alpha", "context_window": 4000, "input_modalities": ["text", "image"]},
+                {"slug": "beta", "input_modalities": ["text"]},
+            ]
+        )
+        open_patch, calls = self._parse_counter(catalog)
+        with mock.patch.dict(os.environ, {"CODEX_MODEL_CATALOG": catalog}), open_patch:
+            self.assertEqual(protocol.known_models(), {"alpha", "beta"})
+            self.assertEqual(protocol.model_context_window("alpha"), 4000)
+            self.assertEqual(protocol.model_context_window("beta"), None)
+            self.assertEqual(protocol.image_capable_models(), {"alpha"})
+            self.assertEqual(protocol.known_models(), {"alpha", "beta"})
+        self.assertEqual(calls["count"], 1)
+
+    def test_mutated_catalog_reparses_once_for_all_three_views(self) -> None:
+        catalog = self._write_catalog(
+            [
+                {"slug": "alpha", "context_window": 4000, "input_modalities": ["text", "image"]},
+                {"slug": "beta", "input_modalities": ["text"]},
+            ]
+        )
+        open_patch, calls = self._parse_counter(catalog)
+        with mock.patch.dict(os.environ, {"CODEX_MODEL_CATALOG": catalog}), open_patch:
+            self.assertEqual(protocol.image_capable_models(), {"alpha"})
+            self.assertEqual(protocol.model_context_window("alpha"), 4000)
+            self.assertEqual(calls["count"], 1)
+
+            with open(catalog, "w") as handle:
+                json.dump(
+                    {
+                        "models": [
+                            {"slug": "gamma", "context_window": 8000, "input_modalities": ["text", "image"]}
+                        ]
+                    },
+                    handle,
+                )
+            self._bump_mtime(catalog)
+
+            self.assertEqual(protocol.known_models(), {"gamma"})
+            self.assertEqual(protocol.model_context_window("gamma"), 8000)
+            self.assertEqual(protocol.image_capable_models(), {"gamma"})
+        self.assertEqual(calls["count"], 2)
+
+    def test_reload_known_models_bypasses_mtime_cache(self) -> None:
+        catalog = self._write_catalog([{"slug": "alpha", "input_modalities": ["text"]}])
+        open_patch, calls = self._parse_counter(catalog)
+        with mock.patch.dict(os.environ, {"CODEX_MODEL_CATALOG": catalog}), open_patch:
+            self.assertEqual(protocol.known_models(), {"alpha"})
+            # Same path and mtime: the cache must not serve the forced re-read.
+            self.assertEqual(protocol.reload_known_models(), {"alpha"})
+        self.assertEqual(calls["count"], 2)
 
 
 class ImageRoutingTests(unittest.TestCase):

--- a/tests/test_quota.py
+++ b/tests/test_quota.py
@@ -30,6 +30,16 @@ def make_config() -> ProxyConfig:
     )
 
 
+@pytest.fixture(autouse=True)
+def no_quota_write_interval(monkeypatch) -> None:
+    """Persistence tests assert each distinct snapshot lands immediately.
+
+    The write throttle is production behavior; the tests that exercise it
+    re-enable the interval explicitly.
+    """
+    monkeypatch.setattr("opencode_go_proxy.quota.WRITE_INTERVAL_SECONDS", 0.0)
+
+
 def chat_payload() -> dict:
     return {"model": "deepseek-v4-flash", "messages": [{"role": "user", "content": "hi"}]}
 
@@ -185,6 +195,56 @@ class TestPersistence:
             record_quota_from_headers({"x-ratelimit-remaining": "1"})  # must not raise
 
 
+class TestWriteThrottle:
+    def test_identical_snapshot_skips_write(self) -> None:
+        # A fixed sampledAt makes the second snapshot field-wise identical to
+        # the persisted one, so the write (and its fsync) must be skipped.
+        with mock.patch("opencode_go_proxy.quota._iso_at", return_value="2026-08-14T00:00:00.000Z"), \
+             mock.patch("opencode_go_proxy.quota.os.fsync") as fsync:
+            record_quota_from_headers({"x-ratelimit-limit-requests": "500", "x-ratelimit-remaining-requests": "42"})
+            record_quota_from_headers({"x-ratelimit-limit-requests": "500", "x-ratelimit-remaining-requests": "42"})
+        assert fsync.call_count == 1
+        assert read_quota_state()["providers"]["openai"]["remaining"] == 42
+
+    def test_interval_throttle_limits_writes(self, monkeypatch) -> None:
+        monkeypatch.setattr("opencode_go_proxy.quota.WRITE_INTERVAL_SECONDS", 1.0)
+        # 100.0s for the first write's interval check and stamp, 100.5s for
+        # the second record's interval check: 0.5s < 1s, so it is dropped.
+        with mock.patch("opencode_go_proxy.quota.time.monotonic", side_effect=[100.0, 100.0, 100.5]):
+            record_quota_from_headers({"x-ratelimit-remaining-requests": "10"})
+            record_quota_from_headers({"x-ratelimit-remaining-requests": "90"})
+        assert read_quota_state()["providers"]["openai"]["remaining"] == 10
+        # Once the interval has elapsed the newer snapshot persists.
+        with mock.patch("opencode_go_proxy.quota.time.monotonic", return_value=102.5):
+            record_quota_from_headers({"x-ratelimit-remaining-requests": "90"})
+        assert read_quota_state()["providers"]["openai"]["remaining"] == 90
+
+    def test_fresh_state_dir_not_throttled_by_previous_writes(self, monkeypatch, tmp_path) -> None:
+        monkeypatch.setattr("opencode_go_proxy.quota.WRITE_INTERVAL_SECONDS", 1.0)
+        first_dir = tmp_path / "quota-a"
+        second_dir = tmp_path / "quota-b"
+        first_dir.mkdir()
+        second_dir.mkdir()
+        with mock.patch.dict(os.environ, {"OPENCODE_GO_PROXY_STATE_DIR": str(first_dir)}):
+            record_quota_from_headers({"x-ratelimit-remaining-requests": "10"})
+        # A different state dir is a different file: the first write there must
+        # not be throttled even though the previous write was milliseconds ago.
+        with mock.patch.dict(os.environ, {"OPENCODE_GO_PROXY_STATE_DIR": str(second_dir)}):
+            record_quota_from_headers({"x-ratelimit-remaining-requests": "20"})
+        with mock.patch.dict(os.environ, {"OPENCODE_GO_PROXY_STATE_DIR": str(second_dir)}):
+            assert read_quota_state()["providers"]["openai"]["remaining"] == 20
+
+    def test_read_quota_state_memoized_until_file_changes(self) -> None:
+        record_quota_from_headers({"x-ratelimit-remaining-requests": "7"})
+        first = read_quota_state()
+        # Unchanged file: the memo serves the second read with no parse.
+        with mock.patch("opencode_go_proxy.quota.open", side_effect=AssertionError("re-read")):
+            second = read_quota_state()
+        assert first == second == {"providers": {"openai": {
+            "provider": "openai", "remaining": 7, "sampledAt": mock.ANY,
+        }}}
+
+
 def ok_response(headers: dict | None = None) -> mock.Mock:
     raw = json.dumps({"choices": [{"message": {"content": "hi"}}]}).encode("utf-8")
     return mock.Mock(status=200, headers=headers or {}, read=lambda: raw,
@@ -203,7 +263,7 @@ class TestUpstreamHooks:
     def test_call_upstream_chat_verbatim_records_quota(self) -> None:
         with mock.patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "test-key"}), \
              mock.patch("urllib.request.urlopen", return_value=ok_response({"x-ratelimit-remaining": "7"})):
-            status, _body, _retries, _ct = call_upstream_chat_verbatim(chat_payload(), make_config(), "req")
+            status, _body, _retries, _ct, _retry_after = call_upstream_chat_verbatim(chat_payload(), make_config(), "req")
         assert status == 200
         assert read_quota_state()["providers"]["openai"]["remaining"] == 7
 

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -90,5 +90,50 @@ class RouteTargetTests(unittest.TestCase):
         self.assertEqual(route_target("gpt-5.5"), "native")
 
 
+class ZenRouteTargetTests(unittest.TestCase):
+    def test_zen_prefix_routes_zen(self) -> None:
+        _write_native_capture(["gpt-5.6-luna"])
+        self.assertEqual(route_target("zen/gpt-5.5"), "zen")
+        self.assertEqual(route_target("zen/claude-sonnet-4-5"), "zen")
+
+    def test_bare_zen_model_id_never_routes_zen(self) -> None:
+        # deepseek-v4-flash exists on zen, but bare slugs never route zen: the
+        # zen models are only reachable with the zen/ prefix.
+        _write_native_capture(["gpt-5.6-luna"])
+        self.assertEqual(route_target("deepseek-v4-flash"), "opencode_go")
+        self.assertEqual(route_target("claude-sonnet-4-5"), "opencode_go")
+
+    def test_opencode_go_prefix_wins_over_zen(self) -> None:
+        _write_native_capture(["gpt-5.6-luna"])
+        self.assertEqual(route_target("opencode-go/claude-sonnet-4-5"), "opencode_go")
+        self.assertEqual(route_target("opencode-go/gpt-5.5"), "opencode_go")
+
+    def test_zen_prefix_wins_over_bare_native_collision(self) -> None:
+        # A user-selected zen/<slug> whose bare slug is a native model must
+        # stay on the zen path: it must never reach the native backend.
+        _write_native_capture(["gpt-5.6-luna"])
+        self.assertEqual(route_target("zen/gpt-5.6-luna"), "zen")
+
+    def test_native_unchanged_with_zen_routes(self) -> None:
+        _write_native_capture(["gpt-5.6-luna"])
+        self.assertEqual(route_target("gpt-5.6-luna"), "native")
+        self.assertEqual(route_target("zen/gpt-5.6-luna"), "zen")
+        self.assertEqual(route_target("opencode-go/gpt-5.6-luna"), "opencode_go")
+
+
+class NormalizeZenSlugTests(unittest.TestCase):
+    def test_strips_zen_prefix(self) -> None:
+        self.assertEqual(normalize_model_slug("zen/gpt-5.5"), "gpt-5.5")
+        self.assertEqual(normalize_model_slug("zen/claude-sonnet-4-5"), "claude-sonnet-4-5")
+
+    def test_opencode_go_prefix_still_stripped(self) -> None:
+        self.assertEqual(normalize_model_slug("opencode-go/deepseek-v4-flash"), "deepseek-v4-flash")
+
+    def test_prefixes_do_not_cross_contaminate(self) -> None:
+        self.assertEqual(normalize_model_slug("opencode-go-zen/qwen3"), "opencode-go-zen/qwen3")
+        self.assertEqual(normalize_model_slug("zen-opencode-go/gpt-5.5"), "zen-opencode-go/gpt-5.5")
+        self.assertEqual(normalize_model_slug("zen/deepseek-v4-flash"), "deepseek-v4-flash")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -90,6 +90,26 @@ class TestUsageSummary:
         assert summary["todayTokens"] == 7
         assert summary["model"] == "m"
 
+    def test_state_usage_consistent_across_fold_and_rescan(self) -> None:
+        # The all-provider summary and the zen rollup both read the same fold;
+        # forcing a rescan must not change the numbers /state reports.
+        import os as _os
+
+        from opencode_go_proxy.meter import usage_events_path
+
+        record_at(datetime.datetime(2026, 8, 11, 3, 30, tzinfo=UTC), model="deepseek-v4-flash",
+                  status=200, duration_ms=100, total_tokens=50, provider="zen")
+        record_at(datetime.datetime(2026, 8, 11, 2, 0, tzinfo=UTC), model="deepseek-v4-flash",
+                  status=200, duration_ms=100, total_tokens=25)
+        folded = build_state(port=8787, upstream="u", now=NOW)
+        _os.utime(usage_events_path())
+        rescanned = build_state(port=8787, upstream="u", now=NOW)
+        assert folded["usage"]["todayTurns"] == rescanned["usage"]["todayTurns"] == 2
+        assert folded["usage"]["todayTokens"] == rescanned["usage"]["todayTokens"] == 75
+        assert folded["usage"]["zen"] == rescanned["usage"]["zen"] == {
+            "todayTurns": 1, "todayTokens": 50, "last7d": [0, 0, 0, 0, 0, 0, 50],
+        }
+
 
 class TestBuildState:
     def test_empty_state_defaults(self) -> None:

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -6,6 +6,7 @@ import socket
 import threading
 from http.client import HTTPConnection
 from http.server import ThreadingHTTPServer
+from typing import ClassVar
 
 import pytest
 
@@ -18,6 +19,12 @@ from opencode_go_proxy.state import build_state, usage_summary
 UTC = datetime.UTC
 TZ = datetime.timezone(datetime.timedelta(hours=5, minutes=30))
 NOW = datetime.datetime(2026, 8, 11, 10, 0, tzinfo=TZ)
+
+
+@pytest.fixture(autouse=True)
+def no_network_usage_poll(monkeypatch) -> None:
+    """/state must never hit the live usage endpoint or keychain in tests."""
+    monkeypatch.setattr("opencode_go_proxy.state.poll_go_usage", lambda _config=None: None)
 
 
 def record_at(dt_utc: datetime.datetime, **kwargs) -> None:
@@ -136,6 +143,55 @@ class TestBuildState:
         assert build_state(port=8787, upstream="u", now=NOW)["quota"] is None
 
 
+class TestUsageKey:
+    GO: ClassVar[dict[str, object]] = {
+        "rolling": {"status": "ok", "percent": 26, "resetsAt": "2026-08-14T05:00:00Z"},
+        "weekly": {"status": "ok", "percent": 41, "resetsAt": "2026-08-16T00:00:00Z"},
+        "monthly": {"status": "ok", "percent": 12, "resetsAt": "2026-08-31T00:00:00Z"},
+    }
+
+    def test_go_usage_from_poller(self, monkeypatch) -> None:
+        monkeypatch.setattr("opencode_go_proxy.state.poll_go_usage", lambda _config=None: self.GO)
+        state = build_state(port=8787, upstream="u", now=NOW)
+        assert state["usage"]["go"] == self.GO
+
+    def test_go_usage_null_when_poller_returns_none(self) -> None:
+        state = build_state(port=8787, upstream="u", now=NOW)
+        assert state["usage"]["go"] is None
+
+    def test_go_limits_exact_values(self) -> None:
+        state = build_state(port=8787, upstream="u", now=NOW)
+        assert state["usage"]["goLimits"] == {
+            "monthlyDollars": 60,
+            "weeklyDollars": 30,
+            "rolling5hDollars": 12,
+            "subscriptionMonthlyDollars": 10,
+        }
+
+    def test_zen_rollup_buckets_provider_events(self) -> None:
+        record_at(datetime.datetime(2026, 8, 11, 3, 30, tzinfo=UTC), model="deepseek-v4-flash",
+                  status=200, duration_ms=100, total_tokens=50, provider="zen")
+        record_at(datetime.datetime(2026, 8, 11, 2, 0, tzinfo=UTC), model="deepseek-v4-flash",
+                  status=200, duration_ms=100, total_tokens=100, provider="zen")
+        record_at(datetime.datetime(2026, 8, 10, 12, 0, tzinfo=UTC), model="deepseek-v4-flash",
+                  status=200, duration_ms=100, total_tokens=30, provider="zen")
+        record_at(datetime.datetime(2026, 8, 11, 1, 0, tzinfo=UTC), model="deepseek-v4-flash",
+                  status=200, duration_ms=100, total_tokens=999)
+        state = build_state(port=8787, upstream="u", now=NOW)
+        zen = state["usage"]["zen"]
+        assert zen["todayTurns"] == 2
+        assert zen["todayTokens"] == 150
+        assert zen["last7d"] == [0, 0, 0, 0, 0, 30, 150]
+
+    def test_legacy_usage_keys_still_present(self) -> None:
+        state = build_state(port=8787, upstream="u", now=NOW)
+        usage = state["usage"]
+        assert set(usage) == {"todayTurns", "todayTokens", "last7d", "go", "goLimits", "zen"}
+        assert usage["todayTurns"] == 0
+        assert usage["todayTokens"] == 0
+        assert len(usage["last7d"]) == 7
+
+
 def make_config(port: int = 8787) -> ProxyConfig:
     return ProxyConfig(
         bind="127.0.0.1", port=port, chat_base_url="https://up.test/v1",
@@ -181,7 +237,9 @@ class TestStateEndpoint:
         assert state["upstream"] == "https://up.test/v1"
         assert state["quota"] is None
         assert state["model"] == DEFAULT_MODEL
-        assert set(state["usage"]) == {"todayTurns", "todayTokens", "last7d"}
+        assert set(state["usage"]) == {"todayTurns", "todayTokens", "last7d", "go", "goLimits", "zen"}
+        assert state["usage"]["go"] is None
+        assert state["usage"]["zen"]["last7d"] == [0, 0, 0, 0, 0, 0, 0]
 
     def test_state_alias_path(self, server) -> None:
         status, _state = get(server, "/v1/state")

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -3,12 +3,15 @@
 import io
 import json
 import os
+import socket
+import struct
+import time
 from unittest import mock
 
 from opencode_go_proxy.app import ProxyConfig
 from opencode_go_proxy.meter import usage_events_path
 from opencode_go_proxy.secrets import clear_api_key_cache
-from opencode_go_proxy.streaming import handle_streaming_request
+from opencode_go_proxy.streaming import _client_gone, handle_streaming_request
 
 
 def make_config() -> ProxyConfig:
@@ -130,6 +133,24 @@ class TestEmptyCompletion:
         assert record["status"] == 200
         assert not record.get("emptyCompletion")
 
+    def test_empty_completion_metered_as_502(self, tmp_path) -> None:
+        # Two empty 200s (the retry also empty) end as response.error
+        # empty_completion; the client-visible outcome is a failed turn, so
+        # the meter records 502 with the emptyCompletion marker, never 200.
+        state = str(tmp_path / "state")
+        lines = [b"data: [DONE]\n"]
+        with mock.patch("urllib.request.urlopen", return_value=_UpstreamStream(lines)):
+            events, wfile, meter = _stream(lines, state_dir=state)
+        errors = [e for e in events if e["type"] == "response.error"]
+        assert len(errors) == 1
+        assert errors[0]["error"].get("code") == "empty_completion"
+        assert b"[DONE]" in wfile.getvalue()
+        assert meter
+        record = meter[0]
+        assert record["status"] == 502
+        assert record.get("emptyCompletion") is True
+        assert record.get("retries") == 1
+
 
 class TestOutputIndexes:
     def test_mixed_text_and_tool_calls_get_unique_indexes(self) -> None:
@@ -169,3 +190,51 @@ class TestFinalOnlyToolIndex:
         assert len(added) >= 2
         indices = [e["output_index"] for e in added]
         assert len(set(indices)) == len(indices), f"collision: {indices}"
+
+
+class TestClientGone:
+    """_client_gone peeks the client socket; a closed peer must read as gone.
+
+    On macOS a write to a reset peer does not error, so this peek is the only
+    way a cancelling client becomes visible before the stream ends.
+    """
+
+    @staticmethod
+    def _assert_eventually_gone(sock: socket.socket) -> None:
+        wfile = sock.makefile("wb", 0)  # same shape as handler.wfile
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline:
+            if _client_gone(wfile):
+                return
+            time.sleep(0.005)
+        raise AssertionError("closed peer was never detected as gone")
+
+    def test_alive_peer_is_not_gone(self) -> None:
+        server, client = socket.socketpair()
+        try:
+            assert _client_gone(server.makefile("wb", 0)) is False
+        finally:
+            server.close()
+            client.close()
+
+    def test_peer_fin_reads_as_gone(self) -> None:
+        server, client = socket.socketpair()
+        try:
+            client.close()
+            self._assert_eventually_gone(server)
+        finally:
+            server.close()
+
+    def test_peer_rst_reads_as_gone(self) -> None:
+        server, client = socket.socketpair()
+        try:
+            client.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, struct.pack("ii", 1, 0))
+            client.close()
+            self._assert_eventually_gone(server)
+        finally:
+            server.close()
+
+    def test_socketless_wfile_reads_as_alive(self) -> None:
+        # Test doubles (io.BytesIO) have no peekable socket; the probe must
+        # degrade to the old write-only behavior, never crash the stream.
+        assert _client_gone(io.BytesIO()) is False

--- a/tests/test_upstream.py
+++ b/tests/test_upstream.py
@@ -124,7 +124,7 @@ class TestVerbatimPassthroughClient:
         raw = json.dumps({"choices": [{"message": {"content": "hi"}}]}).encode("utf-8")
         with mock.patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "test-key"}), \
              mock.patch("urllib.request.urlopen", return_value=ok_response()) as urlopen:
-            status, body, retries, _content_type = call_upstream_chat_verbatim(chat_payload(), make_config(), "req")
+            status, body, retries, _content_type, _retry_after = call_upstream_chat_verbatim(chat_payload(), make_config(), "req")
 
         assert status == 200
         assert body == raw
@@ -141,7 +141,7 @@ class TestVerbatimPassthroughClient:
         with mock.patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "test-key"}), \
              mock.patch("urllib.request.urlopen", side_effect=fake_urlopen), \
              mock.patch("opencode_go_proxy.upstream.time.sleep"):
-            status, body, retries, _content_type = call_upstream_chat_verbatim(chat_payload(), make_config(), "req")
+            status, body, retries, _content_type, _retry_after = call_upstream_chat_verbatim(chat_payload(), make_config(), "req")
 
         assert status == 429
         assert body == b'{"error":"down"}'
@@ -151,7 +151,7 @@ class TestVerbatimPassthroughClient:
     def test_permanent_error_relayed_without_retry(self) -> None:
         with mock.patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "test-key"}), \
              mock.patch("urllib.request.urlopen", side_effect=http_error(400)) as urlopen:
-            status, body, retries, _content_type = call_upstream_chat_verbatim(chat_payload(), make_config(), "req")
+            status, body, retries, _content_type, _retry_after = call_upstream_chat_verbatim(chat_payload(), make_config(), "req")
 
         assert status == 400
         assert body == b'{"error":"down"}'

--- a/tests/test_usage_poller.py
+++ b/tests/test_usage_poller.py
@@ -1,6 +1,7 @@
 """Usage poller: OpenCode Go plan usage fetch, TTL cache, failure degradation."""
 
 import json
+import time
 import urllib.error
 import urllib.request
 from typing import Self
@@ -116,3 +117,68 @@ class TestFetch:
         with mock.patch("urllib.request.urlopen") as urlopen:
             assert usage_poller.poll_go_usage(make_config()) is None
         urlopen.assert_not_called()
+
+
+class TestFailureCache:
+    """_fetch_usage retries once per poll, so one poll = two urlopen calls."""
+
+    def _failing_urlopen(self, calls: list):
+        def failing(request, timeout):
+            calls.append(request)
+            raise OSError("connection refused")
+        return failing
+
+    def test_failure_cached_within_ttl_no_network(self, monkeypatch) -> None:
+        monkeypatch.setenv("OPENCODE_GO_API_KEY", "sk-test-usage")
+        calls: list = []
+        with mock.patch("urllib.request.urlopen", side_effect=self._failing_urlopen(calls)):
+            first = usage_poller.poll_go_usage(make_config())
+            second = usage_poller.poll_go_usage(make_config())
+        assert first is None
+        assert second is None
+        # One poll's retry pair only: the second poll was served from the
+        # failure cache with no network.
+        assert len(calls) == 2
+
+    def test_failure_cache_expires(self, monkeypatch) -> None:
+        monkeypatch.setenv("OPENCODE_GO_API_KEY", "sk-test-usage")
+        calls: list = []
+        with mock.patch("urllib.request.urlopen", side_effect=self._failing_urlopen(calls)):
+            assert usage_poller.poll_go_usage(make_config()) is None
+        # Well past the 15s failure TTL: the next poll must hit the network.
+        with mock.patch.object(usage_poller.time, "monotonic", return_value=time.monotonic() + 100), \
+             mock.patch("urllib.request.urlopen", side_effect=self._failing_urlopen(calls)):
+            assert usage_poller.poll_go_usage(make_config()) is None
+        assert len(calls) == 4
+
+    def test_clear_cache_clears_failure_stamp(self, monkeypatch) -> None:
+        monkeypatch.setenv("OPENCODE_GO_API_KEY", "sk-test-usage")
+        calls: list = []
+        with mock.patch("urllib.request.urlopen", side_effect=self._failing_urlopen(calls)):
+            assert usage_poller.poll_go_usage(make_config()) is None
+        usage_poller.clear_cache()
+        with mock.patch("urllib.request.urlopen", side_effect=self._failing_urlopen(calls)):
+            assert usage_poller.poll_go_usage(make_config()) is None
+        assert len(calls) == 4
+
+    def test_success_after_failure_expiry_serves_fresh(self, monkeypatch) -> None:
+        monkeypatch.setenv("OPENCODE_GO_API_KEY", "sk-test-usage")
+        calls: list = []
+
+        def flaky(request, timeout):
+            calls.append(request)
+            if len(calls) <= 2:
+                # Fail the first poll (both its retry attempts), then recover.
+                raise OSError("connection refused")
+            return FakeResponse(json.dumps(USAGE_BODY).encode())
+
+        with mock.patch("urllib.request.urlopen", side_effect=flaky):
+            assert usage_poller.poll_go_usage(make_config()) is None
+        # Past the failure TTL, a healthy endpoint succeeds and is cached.
+        with mock.patch.object(usage_poller.time, "monotonic", return_value=time.monotonic() + 100), \
+             mock.patch("urllib.request.urlopen", side_effect=flaky):
+            assert usage_poller.poll_go_usage(make_config()) == USAGE_BODY["usage"]
+            assert usage_poller.poll_go_usage(make_config()) == USAGE_BODY["usage"]
+        # Poll 1 failed (2 attempts), poll 2 succeeded (1 attempt), poll 3
+        # was served from the success cache.
+        assert len(calls) == 3

--- a/tests/test_usage_poller.py
+++ b/tests/test_usage_poller.py
@@ -1,0 +1,118 @@
+"""Usage poller: OpenCode Go plan usage fetch, TTL cache, failure degradation."""
+
+import json
+import urllib.error
+import urllib.request
+from typing import Self
+from unittest import mock
+
+import pytest
+
+from opencode_go_proxy import usage_poller
+from opencode_go_proxy.config import ProxyConfig
+from opencode_go_proxy.secrets import clear_api_key_cache
+
+USAGE_BODY = {
+    "usage": {
+        "rolling": {"status": "ok", "percent": 26, "resetsAt": "2026-08-14T05:00:00Z"},
+        "weekly": {"status": "ok", "percent": 41, "resetsAt": "2026-08-16T00:00:00Z"},
+        "monthly": {"status": "ok", "percent": 12, "resetsAt": "2026-08-31T00:00:00Z"},
+    }
+}
+
+
+class FakeResponse:
+    """Minimal urllib response double: readable, context-managed."""
+
+    def __init__(self, body: bytes) -> None:
+        self.body = body
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return self.body
+
+
+def make_config() -> ProxyConfig:
+    return ProxyConfig(
+        bind="127.0.0.1",
+        port=8787,
+        chat_base_url="https://opencode.ai/zen/go/v1",
+        api_key_env="OPENCODE_GO_API_KEY",
+        timeout_sec=10,
+        max_body_bytes=1024 * 1024,
+    )
+
+
+@pytest.fixture(autouse=True)
+def isolated_poller(monkeypatch) -> None:
+    """No TTL cache, no API key cache, and never touch the real keychain."""
+    usage_poller.clear_cache()
+    clear_api_key_cache()
+    monkeypatch.delenv("OPENCODE_GO_API_KEY", raising=False)
+    monkeypatch.delenv("OPENCODE_API_KEY", raising=False)
+    monkeypatch.delenv("OPENCODE_GO_USAGE_URL", raising=False)
+    monkeypatch.setattr("opencode_go_proxy.secrets.keychain_services", list)
+    yield
+    usage_poller.clear_cache()
+    clear_api_key_cache()
+
+
+class TestFetch:
+    def test_parses_usage_and_authorizes(self, monkeypatch) -> None:
+        monkeypatch.setenv("OPENCODE_GO_API_KEY", "sk-test-usage")
+        seen: list[urllib.request.Request] = []
+
+        def fake_urlopen(request: urllib.request.Request, timeout: float) -> FakeResponse:
+            seen.append(request)
+            return FakeResponse(json.dumps(USAGE_BODY).encode())
+
+        with mock.patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            usage = usage_poller.poll_go_usage(make_config())
+        assert usage == USAGE_BODY["usage"]
+        assert seen[0].get_header("Authorization") == "Bearer sk-test-usage"
+        assert seen[0].full_url == usage_poller.DEFAULT_USAGE_URL
+
+    def test_ttl_cache_serves_second_call_without_network(self, monkeypatch) -> None:
+        monkeypatch.setenv("OPENCODE_GO_API_KEY", "sk-test-usage")
+        calls: list[urllib.request.Request] = []
+
+        def fake_urlopen(request: urllib.request.Request, timeout: float) -> FakeResponse:
+            calls.append(request)
+            return FakeResponse(json.dumps(USAGE_BODY).encode())
+
+        with mock.patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            first = usage_poller.poll_go_usage(make_config())
+            second = usage_poller.poll_go_usage(make_config())
+        assert first == second == USAGE_BODY["usage"]
+        assert len(calls) == 1
+
+    def test_http_error_returns_none(self, monkeypatch) -> None:
+        monkeypatch.setenv("OPENCODE_GO_API_KEY", "sk-test-usage")
+        error = urllib.error.HTTPError(usage_poller.DEFAULT_USAGE_URL, 500, "boom", None, None)
+        with mock.patch("urllib.request.urlopen", side_effect=error):
+            assert usage_poller.poll_go_usage(make_config()) is None
+
+    def test_network_error_returns_none(self, monkeypatch) -> None:
+        monkeypatch.setenv("OPENCODE_GO_API_KEY", "sk-test-usage")
+        with mock.patch("urllib.request.urlopen", side_effect=OSError("connection refused")):
+            assert usage_poller.poll_go_usage(make_config()) is None
+
+    def test_malformed_body_returns_none(self, monkeypatch) -> None:
+        monkeypatch.setenv("OPENCODE_GO_API_KEY", "sk-test-usage")
+        with mock.patch("urllib.request.urlopen", return_value=FakeResponse(b"{not json")):
+            assert usage_poller.poll_go_usage(make_config()) is None
+
+    def test_body_without_usage_key_returns_none(self, monkeypatch) -> None:
+        monkeypatch.setenv("OPENCODE_GO_API_KEY", "sk-test-usage")
+        with mock.patch("urllib.request.urlopen", return_value=FakeResponse(b'{"error": "no usage"}')):
+            assert usage_poller.poll_go_usage(make_config()) is None
+
+    def test_missing_api_key_returns_none_without_network(self) -> None:
+        with mock.patch("urllib.request.urlopen") as urlopen:
+            assert usage_poller.poll_go_usage(make_config()) is None
+        urlopen.assert_not_called()

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -323,6 +323,82 @@ class TestCatalogAutoPick:
             assert vision.auto_pick_caption_model() == IMAGE_MODEL_DEFAULT
 
 
+class TestCatalogModelsCache:
+    """catalog_image_models is mtime-memoized: one parse per file change."""
+
+    @staticmethod
+    def _write_catalog(tmp_path, models) -> str:
+        path = tmp_path / "cat.json"
+        path.write_text(json.dumps({"models": models}))
+        return str(path)
+
+    @staticmethod
+    def _bump_mtime(path: str) -> None:
+        stamp = os.stat(path).st_mtime_ns + 1_000_000_000
+        os.utime(path, ns=(stamp, stamp))
+
+    def test_stable_file_read_once_across_calls(self, tmp_path) -> None:
+        cat = self._write_catalog(
+            tmp_path,
+            [
+                {"slug": "mimo-v2.5", "input_modalities": ["text", "image"]},
+                {"slug": "text-only", "input_modalities": ["text"]},
+            ],
+        )
+        real_load = vision.json.load
+        parses = {"count": 0}
+
+        def counting_load(*args, **kwargs):
+            parses["count"] += 1
+            return real_load(*args, **kwargs)
+
+        with mock.patch.dict(os.environ, {"CODEX_MODEL_CATALOG": cat}), mock.patch(
+            "opencode_go_proxy.vision.json.load", side_effect=counting_load
+        ):
+            assert [m["slug"] for m in vision.catalog_image_models()] == ["mimo-v2.5"]
+            assert [m["slug"] for m in vision.catalog_image_models()] == ["mimo-v2.5"]
+            assert [m["slug"] for m in vision.catalog_image_models()] == ["mimo-v2.5"]
+        assert parses["count"] == 1
+
+    def test_new_mtime_reparses(self, tmp_path) -> None:
+        cat = self._write_catalog(tmp_path, [{"slug": "old-vision", "input_modalities": ["text", "image"]}])
+        real_load = vision.json.load
+        parses = {"count": 0}
+
+        def counting_load(*args, **kwargs):
+            parses["count"] += 1
+            return real_load(*args, **kwargs)
+
+        with mock.patch.dict(os.environ, {"CODEX_MODEL_CATALOG": cat}), mock.patch(
+            "opencode_go_proxy.vision.json.load", side_effect=counting_load
+        ):
+            assert [m["slug"] for m in vision.catalog_image_models()] == ["old-vision"]
+            cat_path = tmp_path / "cat.json"
+            cat_path.write_text(
+                json.dumps({"models": [{"slug": "new-vision", "input_modalities": ["text", "image"]}]})
+            )
+            self._bump_mtime(cat)
+            assert [m["slug"] for m in vision.catalog_image_models()] == ["new-vision"]
+            assert [m["slug"] for m in vision.catalog_image_models()] == ["new-vision"]
+        assert parses["count"] == 2
+
+    def test_missing_catalog_cached_as_empty(self, tmp_path) -> None:
+        real_load = vision.json.load
+        parses = {"count": 0}
+
+        def counting_load(*args, **kwargs):
+            parses["count"] += 1
+            return real_load(*args, **kwargs)
+
+        missing = str(tmp_path / "missing.json")
+        with mock.patch.dict(os.environ, {"CODEX_MODEL_CATALOG": missing}), mock.patch(
+            "opencode_go_proxy.vision.json.load", side_effect=counting_load
+        ):
+            assert vision.catalog_image_models() == []
+            assert vision.catalog_image_models() == []
+        assert parses["count"] == 0
+
+
 class TestEngineResolution:
     def test_auto_orders_local_before_remote_when_enabled(self) -> None:
         with mock.patch.object(vision, "local_runtime_enabled", return_value=True):
@@ -383,6 +459,53 @@ class TestLocalProbe:
     def test_disabled_when_payload_malformed(self) -> None:
         with mock.patch("urllib.request.urlopen", side_effect=json.JSONDecodeError("x", "y", 0)):
             assert vision.local_runtime_enabled() is False
+
+
+class TestLocalProbeCache:
+    """The probe cache stays bounded: expired entries swept, oldest evicted."""
+
+    def test_single_slot_keeps_only_most_recent(self) -> None:
+        base = 1_000_000.0
+        with mock.patch.object(vision, "_LOCAL_PROBE_MAX_ENTRIES", 1), mock.patch(
+            "opencode_go_proxy.vision.time.time", return_value=base
+        ), mock.patch(
+            "urllib.request.urlopen",
+            return_value=_FakeResponse(200, {"data": [{"id": "qwen2.5vl:3b"}]}),
+        ):
+            for index in range(5):
+                assert vision.local_runtime_enabled(base_url=f"http://127.0.0.1:{10000 + index}/v1") is True
+                assert len(vision._LOCAL_PROBE_CACHE) <= 1
+
+    def test_cap_evicts_oldest_beyond_max(self) -> None:
+        base = 2_000_000.0
+        with mock.patch.object(vision, "_LOCAL_PROBE_MAX_ENTRIES", 2), mock.patch(
+            "opencode_go_proxy.vision.time.time", return_value=base
+        ), mock.patch(
+            "urllib.request.urlopen",
+            return_value=_FakeResponse(200, {"data": [{"id": "qwen2.5vl:3b"}]}),
+        ):
+            assert vision.local_runtime_enabled(base_url="http://127.0.0.1:10001/v1") is True
+            assert vision.local_runtime_enabled(base_url="http://127.0.0.1:10002/v1") is True
+            assert vision.local_runtime_enabled(base_url="http://127.0.0.1:10003/v1") is True
+            assert len(vision._LOCAL_PROBE_CACHE) == 2
+
+    def test_expired_entries_swept_on_access(self) -> None:
+        with mock.patch.object(vision, "_LOCAL_PROBE_MAX_ENTRIES", 8), mock.patch(
+            "opencode_go_proxy.vision.time.time", return_value=100.0
+        ), mock.patch(
+            "urllib.request.urlopen",
+            return_value=_FakeResponse(200, {"data": [{"id": "qwen2.5vl:3b"}]}),
+        ):
+            vision._LOCAL_PROBE_CACHE[("http://127.0.0.1:10001/v1", "qwen2.5vl:3b")] = (1.0, True)
+            vision._LOCAL_PROBE_CACHE[("http://127.0.0.1:10002/v1", "qwen2.5vl:3b")] = (2.0, False)
+        assert len(vision._LOCAL_PROBE_CACHE) == 2
+        with mock.patch("opencode_go_proxy.vision.time.time", return_value=100.0), mock.patch(
+            "urllib.request.urlopen",
+            return_value=_FakeResponse(200, {"data": [{"id": "qwen2.5vl:3b"}]}),
+        ):
+            vision.local_runtime_enabled(base_url="http://127.0.0.1:10003/v1")
+        assert len(vision._LOCAL_PROBE_CACHE) == 1
+        assert ("http://127.0.0.1:10003/v1", "qwen2.5vl:3b") in vision._LOCAL_PROBE_CACHE
 
 
 class TestRemoteAdapter:

--- a/tests/test_zen_catalog.py
+++ b/tests/test_zen_catalog.py
@@ -1,0 +1,330 @@
+"""Zen catalog: family resolution, capture TTL/fallback, and merged-catalog wiring.
+
+All network is mocked; the real opencode.ai and models.dev endpoints are
+never touched.
+"""
+
+import datetime
+import json
+import os
+import unittest
+import urllib.error
+from typing import Self
+from unittest import mock
+
+from opencode_go_proxy import catalog, zen_catalog
+from opencode_go_proxy.meter import state_dir
+
+ZEN_PAYLOAD = {
+    "object": "list",
+    "data": [
+        {"id": "claude-sonnet-4-5", "object": "model", "created": 1, "owned_by": "zen"},
+        {"id": "gemini-3-pro", "object": "model", "created": 1, "owned_by": "zen"},
+        {"id": "gpt-5.5", "object": "model", "created": 1, "owned_by": "zen"},
+        {"id": "grok-4.5", "object": "model", "created": 1, "owned_by": "zen"},
+        {"id": "deepseek-v4-flash", "object": "model", "created": 1, "owned_by": "zen"},
+        {"id": "qwen3-coder", "object": "model", "created": 1, "owned_by": "zen"},
+    ],
+}
+
+# Realistic models.dev family values for the opencode provider, including the
+# qwen case that must NOT override the prefix rules.
+MODELS_DEV_PAYLOAD = {
+    "opencode": {
+        "models": {
+            "claude-sonnet-4-5": {"family": "claude-sonnet"},
+            "gemini-3-pro": {"family": "gemini-pro"},
+            "gpt-5.5": {"family": "gpt"},
+            "grok-4.5": {"family": "grok"},
+            "deepseek-v4-flash": {"family": "deepseek-flash"},
+            "qwen3-coder": {"family": "qwen"},
+        }
+    }
+}
+
+NOW = datetime.datetime(2026, 8, 14, 12, 0, 0, tzinfo=datetime.UTC)
+
+
+class FakeResponse:
+    """Minimal urllib response: json.load(resp) calls resp.read()."""
+
+    def __init__(self, payload: dict) -> None:
+        self._payload = payload
+        self.status = 200
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *exc: object) -> bool:
+        return False
+
+    def read(self) -> bytes:
+        return json.dumps(self._payload).encode("utf-8")
+
+
+def fake_urlopen(payloads: dict[str, dict]):
+    """urlopen side effect routing by URL substring; anything else fails the test."""
+
+    def _open(request, timeout=None):
+        url = request.full_url if hasattr(request, "full_url") else str(request)
+        for marker, payload in payloads.items():
+            if marker in url:
+                return FakeResponse(payload)
+        raise AssertionError(f"unexpected urlopen call: {url}")
+
+    return _open
+
+
+def _clear_caches() -> None:
+    zen_catalog._ZEN_MODELS_CACHE = None
+    zen_catalog._ZEN_FAMILIES_CACHE = None
+
+
+def _seed_zen_cache(entries: list[dict], families: dict[str, str] | None = None) -> None:
+    """Write zen cache files directly so merged-catalog tests need no network."""
+    state = state_dir()
+    os.makedirs(state, exist_ok=True)
+    with open(zen_catalog.zen_models_path(), "w") as handle:
+        json.dump({"fetched_at": "2026-08-14T00:00:00+00:00", "models": entries}, handle)
+    if families is None:
+        families = {entry["id"]: zen_catalog.resolve_family(entry["id"]) for entry in entries}
+    with open(zen_catalog.zen_catalog_path(), "w") as handle:
+        json.dump(
+            {"version": 1, "fetched_at": "2026-08-14T00:00:00+00:00",
+             "models": {model_id: {"family": family} for model_id, family in sorted(families.items())}},
+            handle,
+        )
+    _clear_caches()
+
+
+class ResolveFamilyTests(unittest.TestCase):
+    def test_prefix_fallback_rules(self) -> None:
+        cases = {
+            "claude-sonnet-4-5": "anthropic_messages",
+            "claude-opus-5": "anthropic_messages",
+            "qwen3-coder": "anthropic_messages",
+            "gemini-3-pro": "google_gemini",
+            "gpt-5.5": "openai_responses",
+            "grok-4.5": "openai_responses",
+            "deepseek-v4-flash": "openai_chat",
+            "glm-4.6": "openai_chat",
+            "minimax-m3": "openai_chat",
+            "kimi-k2": "openai_chat",
+            "deepseek-v4-flash-free": "openai_chat",
+            "big-pickle": "openai_chat",
+        }
+        for model_id, expected in cases.items():
+            with self.subTest(model_id=model_id):
+                self.assertEqual(zen_catalog.resolve_family(model_id), expected)
+
+    def test_generic_models_dev_family_overrides_prefix(self) -> None:
+        # models.dev classifies deepseek-v4-flash as anthropic here; the
+        # metadata wins over the prefix fallback.
+        families = {"deepseek-v4-flash": "anthropic"}
+        self.assertEqual(zen_catalog.resolve_family("deepseek-v4-flash", families), "anthropic_messages")
+
+    def test_specific_models_dev_families_classify_by_prefix(self) -> None:
+        families = {
+            "claude-sonnet-4-5": "claude-sonnet",
+            "gemini-3-pro": "gemini-pro",
+            "gpt-5.5": "gpt-codex",
+            "grok-4.5": "grok",
+        }
+        self.assertEqual(zen_catalog.resolve_family("claude-sonnet-4-5", families), "anthropic_messages")
+        self.assertEqual(zen_catalog.resolve_family("gemini-3-pro", families), "google_gemini")
+        self.assertEqual(zen_catalog.resolve_family("gpt-5.5", families), "openai_responses")
+        self.assertEqual(zen_catalog.resolve_family("grok-4.5", families), "openai_responses")
+
+    def test_unmapped_models_dev_family_keeps_prefix_fallback(self) -> None:
+        # models.dev groups qwen with the compatible crowd; zen still routes
+        # qwen through the anthropic messages surface, so the metadata must
+        # not override the prefix rules here.
+        families = {"qwen3-coder": "qwen"}
+        self.assertEqual(zen_catalog.resolve_family("qwen3-coder", families), "anthropic_messages")
+
+    def test_empty_models_dev_map_falls_back(self) -> None:
+        self.assertEqual(zen_catalog.resolve_family("gemini-3-pro", {}), "google_gemini")
+
+
+class CaptureZenModelsTests(unittest.TestCase):
+    def setUp(self) -> None:
+        os.makedirs(state_dir(), exist_ok=True)
+        _clear_caches()
+
+    def tearDown(self) -> None:
+        _clear_caches()
+
+    def test_capture_success_persists_cache_and_families(self) -> None:
+        urlopen = fake_urlopen({"zen/v1/models": ZEN_PAYLOAD, "models.dev": MODELS_DEV_PAYLOAD})
+        with mock.patch("urllib.request.urlopen", side_effect=urlopen):
+            result = zen_catalog.capture_zen_models(now=NOW)
+
+        self.assertEqual(result["fetched_at"], NOW.isoformat())
+        self.assertEqual(len(result["models"]), 6)
+        self.assertEqual(
+            zen_catalog.zen_model_ids(),
+            {"claude-sonnet-4-5", "gemini-3-pro", "gpt-5.5", "grok-4.5", "deepseek-v4-flash", "qwen3-coder"},
+        )
+        families = zen_catalog.zen_families()
+        self.assertEqual(families["claude-sonnet-4-5"], "anthropic_messages")
+        self.assertEqual(families["gemini-3-pro"], "google_gemini")
+        self.assertEqual(families["gpt-5.5"], "openai_responses")
+        self.assertEqual(families["grok-4.5"], "openai_responses")
+        self.assertEqual(families["deepseek-v4-flash"], "openai_chat")
+        self.assertEqual(families["qwen3-coder"], "anthropic_messages")
+        self.assertTrue(os.path.exists(zen_catalog.zen_models_path()))
+        self.assertTrue(os.path.exists(zen_catalog.zen_catalog_path()))
+
+    def test_fresh_cache_skips_network(self) -> None:
+        _seed_zen_cache(ZEN_PAYLOAD["data"])
+
+        def fail_if_called(*args, **kwargs) -> None:
+            raise AssertionError("capture must not fetch when the cache is fresh")
+
+        with mock.patch("urllib.request.urlopen", side_effect=fail_if_called):
+            result = zen_catalog.capture_zen_models(now=NOW)
+        self.assertEqual(len(result["models"]), 6)
+
+    def test_stale_cache_retries_once_then_falls_back(self) -> None:
+        with open(zen_catalog.zen_models_path(), "w") as handle:
+            json.dump(
+                {"fetched_at": "2026-08-01T00:00:00+00:00", "models": ZEN_PAYLOAD["data"][:2]},
+                handle,
+            )
+        _clear_caches()
+        calls: list[str] = []
+
+        def failing_urlopen(request, timeout=None):
+            calls.append(str(request))
+            raise urllib.error.URLError("offline")
+
+        with mock.patch("urllib.request.urlopen", side_effect=failing_urlopen):
+            result = zen_catalog.capture_zen_models(now=NOW)
+
+        self.assertEqual(len(calls), 2)  # first attempt plus one retry
+        self.assertEqual(result["fetched_at"], "2026-08-01T00:00:00+00:00")
+        self.assertEqual([e["id"] for e in result["models"]], ["claude-sonnet-4-5", "gemini-3-pro"])
+        self.assertEqual(zen_catalog.zen_model_ids(), {"claude-sonnet-4-5", "gemini-3-pro"})
+
+    def test_fetch_failure_with_nothing_cached_returns_empty(self) -> None:
+        with mock.patch(
+            "urllib.request.urlopen", side_effect=urllib.error.URLError("offline")
+        ):
+            result = zen_catalog.capture_zen_models(now=NOW)
+        self.assertEqual(result["models"], [])
+        self.assertEqual(zen_catalog.zen_model_ids(), set())
+        self.assertFalse(os.path.exists(zen_catalog.zen_models_path()))
+
+    def test_refresh_disabled_by_env(self) -> None:
+        _seed_zen_cache(ZEN_PAYLOAD["data"][:2])
+
+        def fail_if_called(*args, **kwargs) -> None:
+            raise AssertionError("capture must not fetch when refresh is disabled")
+
+        with mock.patch.dict(os.environ, {zen_catalog.ZEN_MODELS_REFRESH_ENV: "0"}), mock.patch(
+            "urllib.request.urlopen", side_effect=fail_if_called
+        ):
+            result = zen_catalog.capture_zen_models(now=NOW)
+        self.assertEqual(len(result["models"]), 2)
+
+
+class ZenMtimeCacheTests(unittest.TestCase):
+    def setUp(self) -> None:
+        os.makedirs(state_dir(), exist_ok=True)
+        _clear_caches()
+
+    def tearDown(self) -> None:
+        _clear_caches()
+
+    def test_zen_model_ids_refresh_on_mtime_change(self) -> None:
+        path = zen_catalog.zen_models_path()
+        with open(path, "w") as handle:
+            json.dump({"fetched_at": "2026-08-14T00:00:00+00:00", "models": [{"id": "gpt-5.5"}]}, handle)
+        self.assertEqual(zen_catalog.zen_model_ids(), {"gpt-5.5"})
+
+        old_mtime = os.stat(path).st_mtime_ns
+        with open(path, "w") as handle:
+            json.dump(
+                {"fetched_at": "2026-08-14T00:00:00+00:00",
+                 "models": [{"id": "gpt-5.5"}, {"id": "claude-sonnet-4-5"}]},
+                handle,
+            )
+        os.utime(path, ns=(old_mtime + 10**9, old_mtime + 10**9))
+        # Same path, newer content: the mtime cache must re-read.
+        self.assertEqual(zen_catalog.zen_model_ids(), {"gpt-5.5", "claude-sonnet-4-5"})
+
+    def test_zen_families_refresh_on_mtime_change(self) -> None:
+        entries = [{"id": "gpt-5.5"}, {"id": "gemini-3-pro"}, {"id": "new-model"}]
+        _seed_zen_cache(
+            entries,
+            families={"gpt-5.5": "openai_responses", "gemini-3-pro": "google_gemini"},
+        )
+        families = zen_catalog.zen_families()
+        self.assertEqual(families["gpt-5.5"], "openai_responses")
+        # Not in the persisted map: resolved on the fly by prefix rules.
+        self.assertEqual(families["new-model"], "openai_chat")
+
+        catalog_path = zen_catalog.zen_catalog_path()
+        old_mtime = os.stat(catalog_path).st_mtime_ns
+        with open(catalog_path, "w") as handle:
+            json.dump(
+                {"version": 1, "fetched_at": "2026-08-14T00:00:00+00:00",
+                 "models": {"gpt-5.5": {"family": "anthropic_messages"},
+                            "gemini-3-pro": {"family": "google_gemini"}}},
+                handle,
+            )
+        os.utime(catalog_path, ns=(old_mtime + 10**9, old_mtime + 10**9))
+        self.assertEqual(zen_catalog.zen_families()["gpt-5.5"], "anthropic_messages")
+
+
+class ZenMergedCatalogTests(unittest.TestCase):
+    def setUp(self) -> None:
+        os.makedirs(state_dir(), exist_ok=True)
+        _clear_caches()
+
+    def tearDown(self) -> None:
+        _clear_caches()
+
+    def test_merged_catalog_contains_zen_records(self) -> None:
+        _seed_zen_cache(ZEN_PAYLOAD["data"])
+        merged = catalog.render_merged_catalog()
+
+        zen_entries = [m for m in merged["models"] if str(m["slug"]).startswith("zen/")]
+        self.assertEqual(len(zen_entries), 6)
+        slugs = {str(m["slug"]) for m in merged["models"]}
+        self.assertIn("zen/claude-sonnet-4-5", slugs)
+        self.assertIn("deepseek-v4-flash", slugs)  # go entry still present
+
+        record = next(m for m in zen_entries if m["slug"] == "zen/claude-sonnet-4-5")
+        self.assertEqual(record["family"], "anthropic_messages")
+        self.assertIsNone(record["availability_nux"])  # object form: dict or null, never a bare string
+        self.assertEqual(record["visibility"], "list")
+        self.assertEqual(record["display_name"], "claude-sonnet-4-5")
+        self.assertEqual(record["comp_hash"], "opencode-go-zen-claude-sonnet-4-5-v1")
+        self.assertIn("instructions_template", record["model_messages"])
+        for key in catalog.CANONICAL_MODEL_KEYS:
+            self.assertIn(key, record)
+
+    def test_merged_catalog_without_zen_capture_has_no_zen_records(self) -> None:
+        merged = catalog.render_merged_catalog()
+        self.assertFalse(any(str(m["slug"]).startswith("zen/") for m in merged["models"]))
+
+    def test_merged_models_serve_zen_slugs_via_v1_models_shape(self) -> None:
+        _seed_zen_cache(ZEN_PAYLOAD["data"])
+        catalog.render_merged_catalog()
+
+        # The exact shape app.py builds for /v1/models.
+        slugs = catalog.merged_model_slugs()
+        shape = {"object": "list", "data": [{"id": slug, "object": "model"} for slug in slugs]}
+        ids = {entry["id"] for entry in shape["data"]}
+        self.assertEqual(len(shape["data"]), len(slugs))
+        self.assertEqual(shape["object"], "list")
+        zen_ids = {model_id for model_id in ids if model_id.startswith("zen/")}
+        self.assertIn("zen/gpt-5.5", zen_ids)
+        self.assertIn("zen/qwen3-coder", zen_ids)
+        # Every zen slug carries the prefix; go and native slugs stay bare.
+        self.assertTrue(all(model_id.startswith("zen/") for model_id in zen_ids))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_zen_upstream.py
+++ b/tests/test_zen_upstream.py
@@ -1,0 +1,779 @@
+"""Unit + integration tests for the zen upstream client (zen_upstream.py).
+
+No network and no real keys: ``urllib.request.urlopen`` is mocked (or pointed
+at a local fake server) and the API key comes from a monkeypatched
+``resolve_api_key``. The zen family map is monkeypatched so tests never depend
+on the machine's zen capture files.
+"""
+
+import http.client
+import io
+import json
+import os
+import threading
+import urllib.error
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import ClassVar
+from unittest import mock
+
+import pytest
+
+from opencode_go_proxy import zen_upstream
+from opencode_go_proxy.app import ProxyConfig
+from opencode_go_proxy.errors import ProxyError
+from opencode_go_proxy.meter import usage_events_path
+from opencode_go_proxy.secrets import clear_api_key_cache
+
+# Bare zen id -> family, mirroring the docs the catalog resolves from.
+FIXTURE_FAMILIES = {
+    "claude-sonnet-4": "anthropic_messages",
+    "qwen3.5-max": "anthropic_messages",
+    "gemini-3-pro": "google_gemini",
+    "gpt-5.6": "openai_responses",
+    "grok-4": "openai_responses",
+    "deepseek-v4-flash": "openai_chat",
+    "glm-5": "openai_chat",
+}
+
+
+def make_config() -> ProxyConfig:
+    return ProxyConfig(
+        bind="127.0.0.1", port=8787, chat_base_url="https://go.test/v1",
+        api_key_env="OPENCODE_GO_API_KEY", timeout_sec=10, max_body_bytes=1024 * 1024,
+    )
+
+
+class _UpstreamStream:
+    def __init__(self, lines: list[bytes], status: int = 200, headers: dict | None = None) -> None:
+        self._lines = list(lines)
+        self.status = status
+        self.headers = headers or {}
+
+    def __iter__(self):
+        return iter(self._lines)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args: object) -> bool:
+        return False
+
+
+class _FakeHandler:
+    """Minimal BaseHTTPRequestHandler stand-in: records status/headers, writes to wfile."""
+
+    def __init__(self) -> None:
+        self.wfile = io.BytesIO()
+        self.status = None
+        self.headers: list[tuple[str, str]] = []
+        self._head_committed = False
+
+    def send_response(self, status: int) -> None:
+        self.status = status
+        self._head_committed = True
+
+    def send_header(self, name: str, value: str) -> None:
+        self.headers.append((name, value))
+
+    def end_headers(self) -> None:
+        pass
+
+    def header(self, name: str) -> str | None:
+        for key, value in self.headers:
+            if key.lower() == name.lower():
+                return value
+        return None
+
+    def body(self) -> bytes:
+        return self.wfile.getvalue()
+
+    def events(self) -> list[dict]:
+        events = []
+        for block in self.body().decode("utf-8").split("\n\n"):
+            block = block.strip()
+            if not block.startswith("data: "):
+                continue
+            data = block[len("data: "):]
+            if data == "[DONE]":
+                continue
+            events.append(json.loads(data))
+        return events
+
+
+def http_error(code: int, body: bytes = b'{"type":"error","error":{"type":"AuthError","message":"boom"}}', retry_after: str | None = None) -> urllib.error.HTTPError:
+    headers = {}
+    if retry_after:
+        headers["retry-after"] = retry_after
+    return urllib.error.HTTPError("https://opencode.ai/zen/v1/chat/completions", code, "err", headers, io.BytesIO(body))
+
+
+def zen_payload(model: str = "zen/deepseek-v4-flash", **overrides) -> dict:
+    payload = {
+        "model": model,
+        "instructions": "You are helpful.",
+        "input": "hello",
+        "stream": True,
+    }
+    payload.update(overrides)
+    return payload
+
+
+@pytest.fixture(autouse=True)
+def _clear_secret_cache() -> None:
+    clear_api_key_cache()
+    yield
+    clear_api_key_cache()
+
+
+@pytest.fixture(autouse=True)
+def _fake_zen_families(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(zen_upstream, "zen_families", lambda: dict(FIXTURE_FAMILIES))
+    monkeypatch.setattr(zen_upstream, "zen_model_ids", lambda: set(FIXTURE_FAMILIES))
+
+
+def _meter_records() -> list[dict]:
+    try:
+        with open(usage_events_path(), encoding="utf-8") as handle:
+            return [json.loads(line) for line in handle if line.strip()]
+    except FileNotFoundError:
+        return []
+
+
+def _fake_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(zen_upstream, "resolve_api_key", lambda config, request_id: "test-key-zen")
+
+
+def _request_body(req: urllib.request.Request) -> dict:
+    return json.loads(req.data.decode("utf-8"))
+
+
+def _request_headers(req: urllib.request.Request) -> dict[str, str]:
+    return {name.lower(): value for name, value in req.headers.items()}
+
+
+class TestFamilyDispatch:
+    @pytest.mark.parametrize(
+        ("slug", "expected_path", "auth_header"),
+        [
+            ("zen/claude-sonnet-4", "/messages", "x-api-key"),
+            ("zen/qwen3.5-max", "/messages", "x-api-key"),
+            ("zen/gemini-3-pro", ":streamGenerateContent?alt=sse", "x-goog-api-key"),
+            ("zen/gpt-5.6", "/responses", "authorization"),
+            ("zen/grok-4", "/responses", "authorization"),
+            ("zen/deepseek-v4-flash", "/chat/completions", "authorization"),
+            ("zen/glm-5", "/chat/completions", "authorization"),
+        ],
+    )
+    def test_family_picks_endpoint_and_auth(
+        self, monkeypatch: pytest.MonkeyPatch, slug: str, expected_path: str, auth_header: str
+    ) -> None:
+        _fake_key(monkeypatch)
+        payload = zen_payload(model=slug)
+        url, _body, headers = zen_upstream._build_zen_request(
+            payload, zen_upstream.zen_family_for(zen_upstream.bare_zen_id(slug)),
+            zen_upstream.bare_zen_id(slug), "test-key-zen", stream=True, session_model=slug,
+        )
+        assert expected_path in url
+        assert url.startswith("https://opencode.ai/zen/v1")
+        if auth_header == "authorization":
+            assert headers["authorization"] == "Bearer test-key-zen"
+            assert "x-api-key" not in headers
+        else:
+            assert headers[auth_header] == "test-key-zen"
+            assert "authorization" not in headers
+
+    def test_zen_prefix_stripped_from_upstream_model(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _fake_key(monkeypatch)
+        url, body, _headers = zen_upstream._build_zen_request(
+            zen_payload(), "openai_chat", "deepseek-v4-flash", "test-key-zen",
+            stream=True, session_model="zen/deepseek-v4-flash",
+        )
+        assert body["model"] == "deepseek-v4-flash"
+        assert url.endswith("/chat/completions")
+
+    def test_unknown_id_defaults_to_chat(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _fake_key(monkeypatch)
+        family = zen_upstream.zen_family_for("brand-new-model")
+        assert family == "openai_chat"
+
+    def test_bare_slug_is_not_stripped(self) -> None:
+        assert zen_upstream.bare_zen_id("deepseek-v4-flash") == "deepseek-v4-flash"
+        assert zen_upstream.bare_zen_id("zen/deepseek-v4-flash") == "deepseek-v4-flash"
+
+
+class TestChatFamily:
+    def test_chat_payload_translation_round_trip(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _fake_key(monkeypatch)
+        raw = json.dumps({
+            "choices": [{"index": 0, "message": {"role": "assistant", "content": "hi"}}],
+            "usage": {"prompt_tokens": 3, "completion_tokens": 1, "total_tokens": 4},
+        }).encode("utf-8")
+        captured: list[urllib.request.Request] = []
+
+        def fake_urlopen(req, **kw):
+            captured.append(req)
+            return mock.Mock(status=200, headers={}, read=lambda: raw, __enter__=lambda s: s, __exit__=lambda *a: False)
+
+        with mock.patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            response = zen_upstream.call_zen_responses(zen_payload(stream=False), make_config(), "req")
+
+        assert len(captured) == 1
+        sent = _request_body(captured[0])
+        # Responses input translated to chat messages with the bare model.
+        assert sent["model"] == "deepseek-v4-flash"
+        assert sent["messages"][0] == {"role": "system", "content": "You are helpful."}
+        assert sent["messages"][1] == {"role": "user", "content": "hello"}
+        assert sent["stream"] is False
+        assert "stream_options" not in sent
+        # Translated back to a responses object.
+        assert response["output_text"] == "hi"
+        assert response["model"] == "zen/deepseek-v4-flash"
+        assert response["usage"]["input_tokens"] == 3
+        assert response["usage"]["output_tokens"] == 1
+
+    def test_stream_request_includes_stream_options(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _fake_key(monkeypatch)
+        captured: list[urllib.request.Request] = []
+        lines = [
+            b'data: {"id":"1","choices":[{"index":0,"delta":{"content":"hi"}}]}\n',
+            b'data: {"id":"1","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}\n',
+            b'data: [DONE]\n',
+        ]
+
+        def fake_urlopen(req, **kw):
+            captured.append(req)
+            return _UpstreamStream(lines)
+
+        handler = _FakeHandler()
+        with mock.patch("urllib.request.urlopen", side_effect=fake_urlopen), \
+             mock.patch("opencode_go_proxy.zen_upstream.keepalive_sec", return_value=60.0):
+            zen_upstream.handle_zen_responses_request(handler, zen_payload(), make_config(), "req")
+
+        sent = _request_body(captured[0])
+        assert sent["stream"] is True
+        assert sent["stream_options"] == {"include_usage": True}
+        events = handler.events()
+        assert events[0]["type"] == "response.created"
+        assert events[0]["response"]["model"] == "zen/deepseek-v4-flash"
+        completed = next(e for e in events if e["type"] == "response.completed")
+        assert completed["response"]["output_text"] == "hi"
+        assert completed["response"]["usage"]["input_tokens"] == 1
+        assert b"data: [DONE]" in handler.body()
+
+    def test_stream_tool_calls_become_function_call_items(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _fake_key(monkeypatch)
+        lines = [
+            b'data: {"id":"1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","function":{"name":"read_file","arguments":"{\\"path\\":"}}]}}]}\n',
+            b'data: {"id":"1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\\"/tmp/x\\"}"}}]}}]}\n',
+            b'data: {"id":"1","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":5,"completion_tokens":2,"total_tokens":7}}\n',
+            b'data: [DONE]\n',
+        ]
+        handler = _FakeHandler()
+        with mock.patch("urllib.request.urlopen", return_value=_UpstreamStream(lines)), \
+             mock.patch("opencode_go_proxy.zen_upstream.keepalive_sec", return_value=60.0):
+            zen_upstream.handle_zen_responses_request(handler, zen_payload(), make_config(), "req")
+
+        completed = next(e for e in handler.events() if e["type"] == "response.completed")
+        calls = [item for item in completed["response"]["output"] if item["type"] == "function_call"]
+        assert len(calls) == 1
+        assert calls[0]["name"] == "read_file"
+        assert calls[0]["arguments"] == '{"path":"/tmp/x"}'
+
+    def test_error_envelope_surfaces_proxy_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _fake_key(monkeypatch)
+        body = b'{"type":"error","error":{"type":"AuthError","message":"invalid key"},"metadata":{}}'
+        with mock.patch("urllib.request.urlopen", side_effect=http_error(401, body=body)), \
+             pytest.raises(ProxyError) as ctx:
+            zen_upstream.call_zen_responses(zen_payload(stream=False), make_config(), "req")
+        assert ctx.value.status == HTTPStatus.UNAUTHORIZED
+        assert ctx.value.error_type == "AuthError"
+        assert ctx.value.message == "invalid key"
+        assert ctx.value.upstream_status == 401
+        records = _meter_records()
+        assert records and records[0]["provider"] == "zen"
+        assert records[0]["status"] == 401
+
+    def test_429_surfaces_retry_after(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _fake_key(monkeypatch)
+
+        def rate_limited(req, **kw):
+            raise http_error(429, retry_after="7")
+
+        with mock.patch("urllib.request.urlopen", side_effect=rate_limited), \
+             mock.patch("opencode_go_proxy.upstream.time.sleep"), \
+             pytest.raises(ProxyError) as ctx:
+            zen_upstream.call_zen_responses(zen_payload(stream=False), make_config(), "req")
+        assert ctx.value.status == HTTPStatus.TOO_MANY_REQUESTS
+        assert "retry after 7s" in ctx.value.message
+
+
+class TestResponsesFamily:
+    def test_verbatim_stream_relay(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _fake_key(monkeypatch)
+        lines = [
+            b'data: {"type":"response.created","response":{"id":"r1","status":"in_progress"}}\n',
+            b'data: {"type":"response.output_text.delta","delta":"hi"}\n',
+            b'data: {"type":"response.completed","response":{"id":"r1","status":"completed"}}\n',
+            b'data: [DONE]\n',
+        ]
+        handler = _FakeHandler()
+        with mock.patch("urllib.request.urlopen", return_value=_UpstreamStream(lines)), \
+             mock.patch("opencode_go_proxy.zen_upstream.keepalive_sec", return_value=60.0):
+            zen_upstream.handle_zen_responses_request(handler, zen_payload(model="zen/gpt-5.6"), make_config(), "req")
+
+        assert handler.status == 200
+        assert handler.header("content-type") == "text/event-stream"
+        # Relay is byte-for-byte: exactly the upstream lines, in order.
+        assert handler.body() == b"".join(lines)
+        records = _meter_records()
+        assert records and records[0]["provider"] == "zen"
+        assert records[0]["status"] == 200
+
+    def test_verbatim_non_stream(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _fake_key(monkeypatch)
+        raw = json.dumps({"id": "r1", "object": "response", "status": "completed", "output_text": "hi"}).encode("utf-8")
+        captured: list[urllib.request.Request] = []
+
+        def fake_urlopen(req, **kw):
+            captured.append(req)
+            return mock.Mock(status=200, headers={}, read=lambda: raw, __enter__=lambda s: s, __exit__=lambda *a: False)
+
+        with mock.patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            response = zen_upstream.call_zen_responses(zen_payload(model="zen/gpt-5.6", stream=False), make_config(), "req")
+
+        assert response["output_text"] == "hi"
+        # The upstream sees the bare id, not the zen/ prefix.
+        assert _request_body(captured[0])["model"] == "gpt-5.6"
+        records = _meter_records()
+        assert records and records[0]["provider"] == "zen"
+
+
+class TestAnthropicFamily:
+    def test_request_shape(self) -> None:
+        payload = {
+            "model": "zen/claude-sonnet-4",
+            "instructions": "Be brief.",
+            "input": [
+                {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hi"}]},
+                {
+                    "type": "function_call",
+                    "call_id": "call_1",
+                    "name": "read_file",
+                    "arguments": '{"path":"/tmp/x"}',
+                },
+                {"type": "function_call_output", "call_id": "call_1", "output": "file contents"},
+                {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "thanks"}]},
+            ],
+            "max_output_tokens": 512,
+            "temperature": 0.5,
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "read_file",
+                        "description": "Read a file.",
+                        "parameters": {"type": "object", "properties": {"path": {"type": "string"}}},
+                    },
+                }
+            ],
+            "tool_choice": {"type": "function", "name": "read_file"},
+        }
+        body = zen_upstream.responses_payload_to_anthropic_payload(payload)
+        assert body["system"] == ["Be brief."]
+        assert body["max_tokens"] == 512
+        assert body["temperature"] == 0.5
+        assert body["tool_choice"] == {"type": "tool", "name": "read_file"}
+        assert body["tools"][0]["name"] == "read_file"
+        assert body["tools"][0]["input_schema"]["properties"]["path"] == {"type": "string"}
+        messages = body["messages"]
+        assert messages[0]["role"] == "user"
+        assert messages[0]["content"][0] == {"type": "text", "text": "hi"}
+        assert messages[1]["role"] == "assistant"
+        assert messages[1]["content"][0] == {
+            "type": "tool_use", "id": "call_1", "name": "read_file", "input": {"path": "/tmp/x"},
+        }
+        assert messages[2]["role"] == "user"
+        assert messages[2]["content"][0]["type"] == "tool_result"
+        assert messages[2]["content"][0]["tool_use_id"] == "call_1"
+        assert messages[2]["content"][0]["content"] == "file contents"
+
+    def test_stream_back_translation(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _fake_key(monkeypatch)
+        lines = [
+            b'event: message_start\n',
+            b'data: {"type":"message_start","message":{"usage":{"input_tokens":4}}}\n',
+            b'\n',
+            b'event: content_block_start\n',
+            b'data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n',
+            b'\n',
+            b'event: content_block_delta\n',
+            b'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hel"}}\n',
+            b'\n',
+            b'event: content_block_delta\n',
+            b'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"lo"}}\n',
+            b'\n',
+            b'event: content_block_stop\n',
+            b'data: {"type":"content_block_stop","index":0}\n',
+            b'\n',
+            b'event: content_block_start\n',
+            b'data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"tu_1","name":"read_file"}}\n',
+            b'\n',
+            b'event: content_block_delta\n',
+            b'data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\\"path\\":"}}\n',
+            b'\n',
+            b'event: content_block_delta\n',
+            b'data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"\\"/tmp/x\\"}"}}\n',
+            b'\n',
+            b'event: content_block_stop\n',
+            b'data: {"type":"content_block_stop","index":1}\n',
+            b'\n',
+            b'event: message_delta\n',
+            b'data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":7}}\n',
+            b'\n',
+            b'event: message_stop\n',
+            b'data: {"type":"message_stop"}\n',
+            b'\n',
+        ]
+        captured: list[urllib.request.Request] = []
+        handler = _FakeHandler()
+
+        def fake_urlopen(req, **kw):
+            captured.append(req)
+            return _UpstreamStream(lines)
+
+        with mock.patch("urllib.request.urlopen", side_effect=fake_urlopen), \
+             mock.patch("opencode_go_proxy.zen_upstream.keepalive_sec", return_value=60.0):
+            zen_upstream.handle_zen_responses_request(handler, zen_payload(model="zen/claude-sonnet-4"), make_config(), "req")
+
+        assert handler.status == 200
+        headers = _request_headers(captured[0])
+        assert headers["x-api-key"] == "test-key-zen"
+        assert headers["anthropic-version"] == "2023-06-01"
+        events = handler.events()
+        deltas = [e["delta"] for e in events if e["type"] == "response.output_text.delta"]
+        assert deltas == ["Hel", "lo"]
+        completed = next(e for e in events if e["type"] == "response.completed")
+        assert completed["response"]["output_text"] == "Hello"
+        assert completed["response"]["usage"]["input_tokens"] == 4
+        assert completed["response"]["usage"]["output_tokens"] == 7
+        calls = [item for item in completed["response"]["output"] if item["type"] == "function_call"]
+        assert len(calls) == 1
+        assert calls[0]["name"] == "read_file"
+        assert calls[0]["arguments"] == '{"path":"/tmp/x"}'
+
+    def test_non_stream_translation(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _fake_key(monkeypatch)
+        raw = json.dumps({
+            "id": "msg_1",
+            "type": "message",
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "Sure"},
+                {"type": "tool_use", "id": "tu_1", "name": "read_file", "input": {"path": "/tmp/x"}},
+            ],
+            "usage": {"input_tokens": 4, "output_tokens": 7},
+        }).encode("utf-8")
+
+        def fake_urlopen(req, **kw):
+            return mock.Mock(status=200, headers={}, read=lambda: raw, __enter__=lambda s: s, __exit__=lambda *a: False)
+
+        with mock.patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            response = zen_upstream.call_zen_responses(
+                zen_payload(model="zen/claude-sonnet-4", stream=False), make_config(), "req"
+            )
+        assert response["output_text"] == "Sure"
+        calls = [item for item in response["output"] if item["type"] == "function_call"]
+        assert len(calls) == 1
+        assert calls[0]["name"] == "read_file"
+        assert calls[0]["arguments"] == '{"path":"/tmp/x"}'
+        assert response["usage"]["input_tokens"] == 4
+
+
+class TestGeminiFamily:
+    def test_request_shape(self) -> None:
+        payload = {
+            "model": "zen/gemini-3-pro",
+            "instructions": "Be concise.",
+            "input": [
+                {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hi"}]},
+                {"type": "function_call", "call_id": "call_1", "name": "read_file", "arguments": '{"path":"/tmp/x"}'},
+                {"type": "function_call_output", "call_id": "call_1", "output": "file contents"},
+            ],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "read_file",
+                        "description": "Read a file.",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ],
+        }
+        body = zen_upstream.responses_payload_to_gemini_payload(payload)
+        assert body["systemInstruction"] == {"parts": [{"text": "Be concise."}]}
+        assert body["contents"][0] == {"role": "user", "parts": [{"text": "hi"}]}
+        # Assistant tool call -> functionCall part.
+        assert body["contents"][1]["role"] == "model"
+        assert body["contents"][1]["parts"] == [{"functionCall": {"name": "read_file", "args": {"path": "/tmp/x"}}}]
+        # Tool result -> user functionResponse part.
+        assert body["contents"][2] == {
+            "role": "user",
+            "parts": [{"functionResponse": {"name": "read_file", "response": {"value": "file contents"}}}],
+        }
+        assert body["tools"][0]["functionDeclarations"][0]["name"] == "read_file"
+
+    def test_stream_back_translation(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _fake_key(monkeypatch)
+        lines = [
+            b'data: {"candidates":[{"content":{"parts":[{"text":"Hi "}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":3,"candidatesTokenCount":1,"totalTokenCount":4}}\n\n',
+            b'data: {"candidates":[{"content":{"parts":[{"text":"there"}]}}]}\n\n',
+            b'data: {"candidates":[{"content":{"parts":[{"functionCall":{"name":"read_file","args":{"path":"/tmp/x"}}}]}}],"usageMetadata":{"promptTokenCount":3,"candidatesTokenCount":4,"totalTokenCount":7}}\n\n',
+        ]
+        captured: list[urllib.request.Request] = []
+        handler = _FakeHandler()
+
+        def fake_urlopen(req, **kw):
+            captured.append(req)
+            return _UpstreamStream(lines)
+
+        with mock.patch("urllib.request.urlopen", side_effect=fake_urlopen), \
+             mock.patch("opencode_go_proxy.zen_upstream.keepalive_sec", return_value=60.0):
+            zen_upstream.handle_zen_responses_request(handler, zen_payload(model="zen/gemini-3-pro"), make_config(), "req")
+
+        assert handler.status == 200
+        assert _request_headers(captured[0])["x-goog-api-key"] == "test-key-zen"
+        url = captured[0].full_url
+        assert url.endswith("/models/gemini-3-pro:streamGenerateContent?alt=sse")
+        events = handler.events()
+        deltas = [e["delta"] for e in events if e["type"] == "response.output_text.delta"]
+        assert deltas == ["Hi ", "there"]
+        completed = next(e for e in events if e["type"] == "response.completed")
+        assert completed["response"]["output_text"] == "Hi there"
+        assert completed["response"]["usage"]["input_tokens"] == 3
+        assert completed["response"]["usage"]["output_tokens"] == 4
+        calls = [item for item in completed["response"]["output"] if item["type"] == "function_call"]
+        assert len(calls) == 1
+        assert calls[0]["name"] == "read_file"
+        assert calls[0]["arguments"] == '{"path":"/tmp/x"}'
+
+    def test_non_stream_translation(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _fake_key(monkeypatch)
+        raw = json.dumps({
+            "candidates": [{"content": {"parts": [{"text": "Hi there"}]}}],
+            "usageMetadata": {"promptTokenCount": 3, "candidatesTokenCount": 2, "totalTokenCount": 5},
+        }).encode("utf-8")
+
+        def fake_urlopen(req, **kw):
+            return mock.Mock(status=200, headers={}, read=lambda: raw, __enter__=lambda s: s, __exit__=lambda *a: False)
+
+        with mock.patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            response = zen_upstream.call_zen_responses(
+                zen_payload(model="zen/gemini-3-pro", stream=False), make_config(), "req"
+            )
+        assert response["output_text"] == "Hi there"
+        assert response["usage"]["total_tokens"] == 5
+
+
+class TestStreamErrorHandling:
+    def test_stream_upstream_error_relayed_with_retry_after(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _fake_key(monkeypatch)
+        body = b'{"type":"error","error":{"type":"RateLimit","message":"slow down"},"metadata":{}}'
+        handler = _FakeHandler()
+
+        def rate_limited(req, **kw):
+            raise http_error(429, body=body, retry_after="3")
+
+        with mock.patch("urllib.request.urlopen", side_effect=rate_limited), \
+             mock.patch("opencode_go_proxy.streaming.time.sleep"):
+            zen_upstream.handle_zen_responses_request(handler, zen_payload(), make_config(), "req")
+
+        assert handler.status == 429
+        assert handler.header("retry-after") == "3"
+        assert handler.header("content-type") == "application/json"
+        assert handler.body() == body
+        # No SSE events were synthesized (connect-first).
+        assert handler.events() == []
+        records = _meter_records()
+        assert records and records[0]["provider"] == "zen"
+        assert records[0]["status"] == 429
+
+    def test_stream_network_error_raises_proxy_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _fake_key(monkeypatch)
+        with mock.patch("urllib.request.urlopen", side_effect=urllib.error.URLError("refused")), \
+             pytest.raises(ProxyError) as ctx:
+            zen_upstream.handle_zen_responses_request(_FakeHandler(), zen_payload(), make_config(), "req")
+        assert ctx.value.status == HTTPStatus.BAD_GATEWAY
+        records = _meter_records()
+        assert records and records[0]["provider"] == "zen"
+        assert records[0]["status"] == 502
+
+    def test_stream_aborted_after_200_meters_502(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _fake_key(monkeypatch)
+        # Upstream opens the stream then dies mid-body (IncompleteRead).
+        class _AbortStream(_UpstreamStream):
+            def __exit__(self, *args: object) -> bool:
+                raise http.client.IncompleteRead(b"partial")
+
+        lines = [b'data: {"id":"1","choices":[{"index":0,"delta":{"content":"partial"}}]}\n']
+        handler = _FakeHandler()
+        with mock.patch("urllib.request.urlopen", return_value=_AbortStream(lines)):
+            zen_upstream.handle_zen_responses_request(handler, zen_payload(), make_config(), "req")
+        assert handler.status == 200  # SSE head was committed
+        records = _meter_records()
+        assert records and records[0]["provider"] == "zen"
+        assert records[0]["status"] == 502
+        assert records[0]["streamAborted"] is True
+
+
+class TestZenChatSurface:
+    def test_stream_relay_to_zen_base(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _fake_key(monkeypatch)
+        lines = [
+            b'data: {"id":"1","choices":[{"index":0,"delta":{"content":"hi"}}]}\n',
+            b'data: {"id":"1","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n',
+            b'data: [DONE]\n',
+        ]
+        captured: list[urllib.request.Request] = []
+        handler = _FakeHandler()
+
+        def fake_urlopen(req, **kw):
+            captured.append(req)
+            return _UpstreamStream(lines)
+
+        with mock.patch("urllib.request.urlopen", side_effect=fake_urlopen), \
+             mock.patch("opencode_go_proxy.zen_upstream.keepalive_sec", return_value=60.0):
+            zen_upstream.handle_zen_chat_request(
+                handler,
+                {"model": "zen/deepseek-v4-flash", "messages": [{"role": "user", "content": "hi"}], "stream": True},
+                make_config(), "req",
+            )
+
+        assert handler.status == 200
+        assert captured[0].full_url.endswith("/chat/completions")
+        assert captured[0].full_url.startswith("https://opencode.ai/zen/v1")
+        assert _request_body(captured[0])["model"] == "deepseek-v4-flash"
+        assert handler.body() == b"".join(lines)
+        records = _meter_records()
+        assert records and records[0]["provider"] == "zen"
+
+    def test_non_stream_relays_status_and_body(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _fake_key(monkeypatch)
+        raw = b'{"choices":[{"message":{"content":"hi"}}]}'
+        handler = _FakeHandler()
+        with mock.patch("urllib.request.urlopen", return_value=mock.Mock(
+            status=200, headers={}, read=lambda: raw, __enter__=lambda s: s, __exit__=lambda *a: False
+        )):
+            zen_upstream.handle_zen_chat_request(
+                handler,
+                {"model": "zen/deepseek-v4-flash", "messages": [{"role": "user", "content": "hi"}]},
+                make_config(), "req",
+            )
+        assert handler.status == 200
+        assert handler.body() == raw
+
+
+class _FakeZenUpstream(BaseHTTPRequestHandler):
+    """Local fake zen /chat/completions + /messages + /responses upstream."""
+
+    mode = "chat-sse"
+    captured: ClassVar[list[dict]] = []
+
+    def _emit(self, status: int, content_type: str, payload: bytes, extra: dict[str, str] | None = None) -> None:
+        self.send_response(status)
+        self.send_header("content-type", content_type)
+        for name, value in (extra or {}).items():
+            self.send_header(name, value)
+        self.send_header("content-length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def do_POST(self) -> None:
+        length = int(self.headers.get("content-length", "0"))
+        body = self.rfile.read(length)
+        type(self).captured.append({"path": self.path, "headers": dict(self.headers), "body": body})
+        if type(self).mode == "chat-sse":
+            payload = (
+                b'data: {"id":"1","choices":[{"index":0,"delta":{"content":"zen-answer"}}]}\n'
+                b'data: {"id":"1","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}\n'
+                b'data: [DONE]\n'
+            )
+            self._emit(200, "text/event-stream", payload)
+            return
+        self._emit(200, "application/json", b'{"choices":[]}')
+
+
+class TestAppDispatch:
+    def test_zen_request_never_reaches_go_path(self, tmp_path) -> None:
+        """End to end: a zen-routed /v1/responses stream is served by the zen
+        client and the opencode-go upstream sees zero traffic."""
+        state = tmp_path / "state"
+        state.mkdir(exist_ok=True)
+        from opencode_go_proxy.app import ResponsesProxyHandler
+
+        go_server = ThreadingHTTPServer(("127.0.0.1", 0), _FakeZenUpstream)
+        zen_server = ThreadingHTTPServer(("127.0.0.1", 0), _FakeZenUpstream)
+        go_thread = threading.Thread(target=go_server.serve_forever, daemon=True)
+        zen_thread = threading.Thread(target=zen_server.serve_forever, daemon=True)
+        go_thread.start()
+        zen_thread.start()
+        try:
+            server = ThreadingHTTPServer(("127.0.0.1", 0), ResponsesProxyHandler)
+            server.config = make_config()  # type: ignore[attr-defined]
+            server.config.chat_base_url = f"http://127.0.0.1:{go_server.server_port}/v1"
+            thread = threading.Thread(target=server.serve_forever, daemon=True)
+            thread.start()
+            _FakeZenUpstream.mode = "chat-sse"
+            _FakeZenUpstream.captured = []
+
+            env = {
+                "OPENCODE_GO_PROXY_STATE_DIR": str(state),
+                "OPENCODE_ZEN_BASE_URL": f"http://127.0.0.1:{zen_server.server_port}/zen/v1",
+            }
+            with mock.patch.dict(os.environ, env), \
+                 mock.patch("opencode_go_proxy.zen_upstream.resolve_api_key", return_value="test-key-zen"), \
+                 mock.patch("opencode_go_proxy.zen_upstream.keepalive_sec", return_value=60.0):
+                import http.client
+
+                conn = http.client.HTTPConnection("127.0.0.1", server.server_port, timeout=10)
+                payload = json.dumps({
+                    "model": "zen/deepseek-v4-flash",
+                    "input": "hello",
+                    "stream": True,
+                })
+                conn.request("POST", "/v1/responses", body=payload, headers={"content-type": "application/json"})
+                resp = conn.getresponse()
+                streamed = resp.read().decode("utf-8")
+                conn.close()
+
+            assert resp.status == 200
+            assert "zen-answer" in streamed
+            assert "response.completed" in streamed
+            # The zen upstream received the translated chat request; the
+            # opencode-go upstream (same fake class, different port) saw none.
+            zen_host = f"127.0.0.1:{zen_server.server_port}"
+            go_host = f"127.0.0.1:{go_server.server_port}"
+            zen_records = [e for e in _FakeZenUpstream.captured if e["headers"].get("Host") == zen_host]
+            go_records = [e for e in _FakeZenUpstream.captured if e["headers"].get("Host") == go_host]
+            assert zen_records, "zen upstream should have received the request"
+            assert not go_records, "opencode-go upstream must never see a zen request"
+            assert zen_records[0]["path"] == "/zen/v1/chat/completions"
+            sent = json.loads(zen_records[0]["body"])
+            assert sent["model"] == "deepseek-v4-flash"
+
+            records = []
+            try:
+                with open(state / "usage-events.jsonl", encoding="utf-8") as handle:
+                    records = [json.loads(line) for line in handle if line.strip()]
+            except FileNotFoundError:
+                pass
+            assert records and records[0]["provider"] == "zen"
+            assert records[0]["status"] == 200
+        finally:
+            server.shutdown()
+            server.server_close()
+            go_server.shutdown()
+            go_server.server_close()
+            zen_server.shutdown()
+            zen_server.server_close()

--- a/tests/test_zen_upstream.py
+++ b/tests/test_zen_upstream.py
@@ -626,6 +626,30 @@ class TestStreamErrorHandling:
         assert records[0]["status"] == 502
         assert records[0]["streamAborted"] is True
 
+    def test_stream_empty_completion_metered_as_502(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _fake_key(monkeypatch)
+        # Two empty 200s (the retry also empty) end as response.error
+        # empty_completion; the client-visible outcome is a failed turn, so
+        # the meter records 502 with the emptyCompletion marker, never 200.
+        lines = [
+            b'data: {"id":"1","choices":[{"index":0,"delta":{"role":"assistant","content":""}}]}\n',
+            b'data: {"id":"1","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n',
+            b'data: [DONE]\n',
+        ]
+        handler = _FakeHandler()
+        with mock.patch("urllib.request.urlopen", return_value=_UpstreamStream(lines)):
+            zen_upstream.handle_zen_responses_request(handler, zen_payload(), make_config(), "req")
+        assert handler.status == 200  # SSE head was committed
+        events = handler.events()
+        errors = [e for e in events if e.get("type") == "response.error"]
+        assert len(errors) == 1
+        assert errors[0]["error"]["code"] == "empty_completion"
+        assert not any(e.get("type") == "response.completed" for e in events)
+        records = _meter_records()
+        assert records and records[0]["provider"] == "zen"
+        assert records[0]["status"] == 502
+        assert records[0]["emptyCompletion"] is True
+
 
 class TestZenChatSurface:
     def test_stream_relay_to_zen_base(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -26,7 +26,7 @@ wheels = [
 
 [[package]]
 name = "opencode-go-proxy"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "zstandard" },


### PR DESCRIPTION
## What
- OpenCode Zen support: auto-discovered 61-model catalog with zen/ prefixed slugs, per-family upstream translation (chat/completions, responses, anthropic messages, gemini generateContent) with auth-header mapping; same keychain key as Go.
- Native remote compaction v1/v2 support (the app's auto-compact works through the proxy).
- Usage: Go usage endpoint polling + fixed Go limits + zen rollup in /state and the menu bar.
- Reliability: retry-after forwarding, empty completions metered 502, macOS client-cancel detection, config backups before mutation.
- Caching: conditional GET with real ETag, mtime-memoized catalogs, O(1) usage aggregates, TTL-cached polls, coalesced catalog parses.
- Coexistence: native GPT models relay verbatim with the client's own auth; go/zen key never crosses paths (absence-tested).

## Verification
- 700 tests + 12 subtests green; ruff clean; swift build clean.
- Failure matrix vs scripted upstream (11 scenarios) green.
- Live e2e: go turn, zen free-model turn (responses + chat surfaces), zen paid-model auth path, live compaction summary, /state usage — all verified against real upstreams.
- ChatGPT external review: 3 rounds, APPROVED; both follow-ups landed.
- Codex app CUA test: 99-model picker (native + go), go turn served through the proxy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OpenCode Zen support and native conversation compaction to the local Codex proxy, with caching and reliability hardening, and bumps to 0.4.0. Before: only OpenCode Go Chat Completions were translated. Now: Zen models stream via family-specific adapters, empty 200s meter as failed 502s, 429 retry-after is forwarded, and the catalog’s `availability_nux` is normalized to `{message: string}`.

- Zen models are auto-discovered and listed as `zen/<id>` in the catalog and `/v1/models`, then routed per family (Anthropic Messages, Gemini, OpenAI Chat, or Responses). Bare slugs never route to Zen; the `zen/` prefix is required. Native models still relay verbatim; Go and Zen auth never mix and share the same key with per-family header mapping.
- Remote compaction supports v1 (`/v1/responses/compact`) and v2 (trigger item in `/v1/responses`), running one non‑streaming upstream call and returning a unified Responses stream.
- Reliability and caching: forwards upstream `retry-after` on 429; meters empty 200-turns as failed 502 with `emptyCompletion`; detects macOS client‑cancels to avoid false‑success metering; backs up Codex config before edits; catalog refresh uses conditional GET with real ETag, a background refresh timer, and mtime‑memoized parses shared across views.
- Usage and quota: O(1) in‑process usage fold; optional Go usage polling (browser UA + one retry, TTL-cached; `OPENCODE_GO_USAGE_URL` override); throttled quota writes; `/state` gains optional `go`, `goLimits`, and `zen` keys; the macOS menu bar shows Go limits/usage and a Zen rollup.

**Rollout and migration**
- To use Zen, prefix models with `zen/` (for example, `zen/gpt-5.5`). Bare IDs keep using OpenCode Go.
- Catalog consumers must handle `availability_nux` as `{message: string}`; the string form is no longer emitted.
- No key changes: Zen uses the same key as Go; the proxy maps auth headers per family. The config manager adds a `model_providers.zen` block unless a user-owned `model_providers.zen` exists; edits are backed up automatically.

<sup>Written for commit 2268555b2f58ecea584f79f8bb866562cccde754. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kartikkabadi/opencode-go-proxy/pull/30?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenCode Zen support across Responses and Chat Completions APIs, with OpenAI, Anthropic, and Gemini model families.
  * Added automatic Zen model discovery, routing, authentication, free models, and separate usage metering.
  * Added remote conversation compaction for supported requests.
  * Expanded status reporting and macOS menu-bar displays for Go limits, Go usage, and Zen usage.
* **Bug Fixes**
  * Improved streaming cancellation, retry handling, error reporting, and catalog refresh reliability.
  * Empty completions now correctly report failure status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->